### PR TITLE
Add SonarQube integration and enhance GitHub Actions for MacOS

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -69,6 +69,7 @@ jobs:
         if: matrix.platform.name == 'MacOS'
         run: |
           dotnet restore
+          dotnet tool update --global dotnet-coverage
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"magic5644_codeLineCounter" /o:"magic5644" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet build --no-incremental
           dotnet-coverage collect 'dotnet test --no-build' -f xml  -o 'coverage.xml'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,8 +31,44 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet.version }}
+
+      - name: Setup Java
+        if: matrix.platform.name == 'MacOS'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Cache SonarCloud packages
+        if: matrix.platform.name == 'MacOS'
+        uses: actions/cache@v4
+        with:
+          path: ~/sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+  
+      - name: Cache SonarCloud scanner
+        if: matrix.platform.name == 'MacOS'
+        id: cache-sonar-scanner
+        uses: actions/cache@v4
+        with:
+          path: ./.sonar/scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+
+      - name: Install SonarCloud scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true' && matrix.platform.name == 'MacOS'
+        shell: pwsh
+        run: |
+          dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
+
       - name: Enforce SDK Version
         run: dotnet new globaljson --sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --force
+
+      - name: pre_build
+        if: matrix.platform.name == 'MacOS'
+        run: ./.sonar/scanner/dotnet-sonarscanner begin /k:"magic5644_codeLineCounter" /o:"magic5644" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+      
       - name: Build
         run: dotnet build -c Release
       - name: Test
@@ -44,6 +80,10 @@ jobs:
           dotnet tool install --global dotnet-reportgenerator-globaltool
           reportgenerator -reports:test-result.cobertura.xml -targetdir:coverage-report -reporttypes:"Html;JsonSummary;MarkdownSummaryGithub;Badges"
           cat coverage-report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+
+      - name: post_build
+        if: matrix.platform.name == 'MacOS'
+        run: ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
   
       - name: ReportGenerator
         if: matrix.platform.name == 'MacOS'
@@ -85,20 +125,7 @@ jobs:
             echo "![Coverage](./coverage-report/badge_combined.svg)" > coverage-badge.md
             cat coverage-badge.md >> README.md
   
-  sonarcloud:
-    name: SonarCloud
-    runs-on: ubuntu-24.04
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 0
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}    
+
 
   publish_badge:
     runs-on: ubuntu-24.04

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,12 +70,12 @@ jobs:
         run: |
           dotnet restore
           dotnet tool update --global dotnet-coverage
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"magic5644_codeLineCounter" /o:"magic5644" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"magic5644_codeLineCounter" /o:"magic5644" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.scanner.scanAll=false
           dotnet build --no-incremental
           dotnet-coverage collect 'dotnet test --no-build' -f xml  -o 'coverage.xml'
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       
-      - name: Build
+      - name: Build Release
         run: dotnet build -c Release
       - name: Test
         if: matrix.platform.name == 'MacOS'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -84,6 +84,13 @@ jobs:
         run: |
             echo "![Coverage](./coverage-report/badge_combined.svg)" > coverage-badge.md
             cat coverage-badge.md >> README.md
+      
+      - name : Sonarqube (SonarCloud)
+        if: matrix.platform.name == 'MacOS'
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        
 
   publish_badge:
     runs-on: ubuntu-24.04

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -84,13 +84,21 @@ jobs:
         run: |
             echo "![Coverage](./coverage-report/badge_combined.svg)" > coverage-badge.md
             cat coverage-badge.md >> README.md
-      
-      - name : Sonarqube (SonarCloud)
-        if: matrix.platform.name == 'MacOS'
-        uses: SonarSource/sonarqube-scan-action@v4.2.1
+  
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v2
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}    
 
   publish_badge:
     runs-on: ubuntu-24.04

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -65,9 +65,14 @@ jobs:
       - name: Enforce SDK Version
         run: dotnet new globaljson --sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --force
 
-      - name: pre_build
+      - name: build and analyze
         if: matrix.platform.name == 'MacOS'
-        run: ./.sonar/scanner/dotnet-sonarscanner begin /k:"magic5644_codeLineCounter" /o:"magic5644" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+        run: |
+          dotnet restore
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"magic5644_codeLineCounter" /o:"magic5644" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+          dotnet build --no-incremental
+          dotnet-coverage collect 'dotnet test --no-build' -f xml  -o 'coverage.xml'
+          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       
       - name: Build
         run: dotnet build -c Release
@@ -80,12 +85,8 @@ jobs:
           dotnet tool install --global dotnet-reportgenerator-globaltool
           reportgenerator -reports:test-result.cobertura.xml -targetdir:coverage-report -reporttypes:"Html;JsonSummary;MarkdownSummaryGithub;Badges"
           cat coverage-report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
-
-      - name: post_build
-        if: matrix.platform.name == 'MacOS'
-        run: ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
   
-      - name: ReportGenerator
+      - name: ReportGenerator_CoverageReport
         if: matrix.platform.name == 'MacOS'
         uses: danielpalme/ReportGenerator-GitHub-Action@5.3.11
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 /codeql*
 /*.dot
 /*snyk*
+
+# Mac OS
+.DS_Store
+.AppleDouble

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,0 @@
-sonar.projectKey=magic5644_codeLineCounter
-sonar.organization=magic5644
-# relative paths to source directories. More details and properties are described
-# at https://docs.sonarsource.com/sonarqube-server/latest/project-administration/analysis-scope/ 
-sonar.sources=.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=magic5644_codeLineCounter
-
+sonar.organization=magic5644
 # relative paths to source directories. More details and properties are described
 # at https://docs.sonarsource.com/sonarqube-server/latest/project-administration/analysis-scope/ 
 sonar.sources=.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=magic5644_codeLineCounter
+
+# relative paths to source directories. More details and properties are described
+# at https://docs.sonarsource.com/sonarqube-server/latest/project-administration/analysis-scope/ 
+sonar.sources=.


### PR DESCRIPTION
Integrate SonarQube for MacOS and update the GitHub Actions workflow to support SonarCloud with caching. Remove obsolete configuration files and update .gitignore for Mac-specific files.