### PR TITLE
Enhance tests and add Moq package for better test coverage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,16 @@
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole"
+        },
+        {
+            "name": "C#: CodeLineCounter - Isacompta",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/CodeLineCounter/bin/Debug/net9.0/CodeLineCounter.dll",
+            "args": ["-d", "E:/_TFS/Isagri.CO/Isagri_Dev_CO_Compta/Isagri.CO/Main/Isaco/DotNet/Sources"],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
         }
     ]
 }

--- a/CodeLineCounter.Tests/CodeLineCounter.Tests.csproj
+++ b/CodeLineCounter.Tests/CodeLineCounter.Tests.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CodeLineCounter.Tests/DataExporterTests.cs
+++ b/CodeLineCounter.Tests/DataExporterTests.cs
@@ -271,28 +271,6 @@ namespace CodeLineCounter.Tests
             Assert.Equal("File path cannot be null or empty (Parameter 'filePath')", exception.Message);
         }
 
-        // ExportCollection throws IOException when there is an IO error during export
-        // [Fact]
-        // public void export_collection_throws_ioexception_on_io_error()
-        // {
-        //     // Arrange
-        //     var filePath = "invalid_path/test.csv";
-        //     var testData = new List<TestClass> { new TestClass() };
-        //     var format = CoreUtils.ExportFormat.CSV;
-
-        //     // Mock the export strategy to throw an IOException
-        //     var mockExportStrategy = new Mock<IExportStrategy>();
-        //     mockExportStrategy
-        //         .Setup(strategy => strategy.Export(It.IsAny<string>(), It.IsAny<IEnumerable<TestClass>>()))
-        //         .Throws(new IOException("IO error"));
-
-        //     DataExporter.ExportStrategies[format] = mockExportStrategy.Object;
-
-        //     // Act & Assert
-        //     Assert.Throws<IOException>(() =>
-        //         DataExporter.ExportCollection(filePath, testData, format));
-        // }
-
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/CodeLineCounter.Tests/DependencyGraphGeneratorTests.cs
+++ b/CodeLineCounter.Tests/DependencyGraphGeneratorTests.cs
@@ -1,5 +1,7 @@
 using CodeLineCounter.Models;
 using CodeLineCounter.Services;
+using DotNetGraph.Core;
+using DotNetGraph.Extensions;
 
 namespace CodeLineCounter.Tests
 {
@@ -18,7 +20,9 @@ namespace CodeLineCounter.Tests
             string outputPath = Path.Combine(Path.GetTempPath(), "test_graph.dot");
 
             // Act
-            await DependencyGraphGenerator.GenerateGraph(dependencies, outputPath);
+
+            DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
+            await DependencyGraphGenerator.CompileGraphAndWriteToFile(outputPath, graph);
 
             // Assert
             Assert.True(File.Exists(outputPath));
@@ -39,7 +43,8 @@ namespace CodeLineCounter.Tests
             string outputPath = Path.Combine(Path.GetTempPath(), "empty_graph.dot");
 
             // Act
-            await DependencyGraphGenerator.GenerateGraph(dependencies, outputPath);
+            DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
+            await DependencyGraphGenerator.CompileGraphAndWriteToFile(outputPath, graph);
 
             // Assert
             Assert.True(File.Exists(outputPath));
@@ -48,6 +53,34 @@ namespace CodeLineCounter.Tests
             Assert.DoesNotContain("->", content);
 
             File.Delete(outputPath);
+        }
+
+        [Fact]
+        public void create_node_sets_correct_fillcolor_and_style_incoming_greater()
+        {
+            var vertexInfo = new Dictionary<string, (int incoming, int outgoing)>
+            {
+                { "TestVertex", (3, 2) }
+            };
+
+            DotNode node = DependencyGraphGenerator.CreateNode(vertexInfo, "TestVertex");
+
+            Assert.Equal(DotColor.MediumSeaGreen.ToHexString(), node.FillColor.Value);
+            Assert.Equal(DotNodeStyle.Filled.FlagsToString(), node.Style.Value);
+        }
+
+        [Fact]
+        public void create_node_sets_correct_fillcolor_and_style_incoming_lower()
+        {
+            var vertexInfo = new Dictionary<string, (int incoming, int outgoing)>
+            {
+                { "TestVertex", (3, 4) }
+            };
+
+            DotNode node = DependencyGraphGenerator.CreateNode(vertexInfo, "TestVertex");
+
+            Assert.Equal(DotColor.Salmon.ToHexString(), node.FillColor.Value);
+            Assert.Equal(DotNodeStyle.Filled.FlagsToString(), node.Style.Value);
         }
 
 

--- a/CodeLineCounter.Tests/FileUtilsTests.cs
+++ b/CodeLineCounter.Tests/FileUtilsTests.cs
@@ -31,5 +31,29 @@ namespace CodeLineCounter.Tests
             Assert.False(string.IsNullOrEmpty(basePath), "Base path should not be null or empty.");
             Assert.True(Directory.Exists(basePath), "Base path should be a valid directory.");
         }
+
+        [Fact]
+        public void get_solution_files_throws_exception_for_nonexistent_directory()
+        {
+            // Arrange
+            var nonExistentPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            // Act & Assert
+            Assert.Throws<UnauthorizedAccessException>(() => FileUtils.GetSolutionFiles(nonExistentPath));
+        }
+
+        // Throws UnauthorizedAccessException when solution file does not exist
+        [Fact]
+        public void get_project_files_throws_when_file_not_exists()
+        {
+            // Arrange
+            var nonExistentPath = "nonexistent.sln";
+
+            // Act & Assert
+            var exception = Assert.Throws<UnauthorizedAccessException>(() =>
+                FileUtils.GetProjectFiles(nonExistentPath));
+
+            Assert.Contains(nonExistentPath, exception.Message);
+        }
     }
 }

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -8,6 +8,40 @@ namespace CodeLineCounter.Tests.Services
     {
 
         [Fact]
+        public void analyze_and_export_solution_succeeds_with_valid_inputs()
+        {
+            // Arrange
+            var basePath = FileUtils.GetBasePath();
+            var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
+            solutionPath = Path.Combine(solutionPath, "CodeLineCounter.sln");
+            var sw = new StringWriter();
+            Console.SetOut(sw);
+            var verbose = false;
+            var format = CoreUtils.ExportFormat.JSON;
+
+            // Act & Assert
+            var exception = Record.Exception(() =>
+                SolutionAnalyzer.AnalyzeAndExportSolution(solutionPath, verbose, format));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void analyze_and_export_solution_throws_on_invalid_path()
+        {
+            // Arrange
+            var invalidPath = "";
+            var verbose = false;
+            var format = CoreUtils.ExportFormat.JSON;
+
+            // Act & Assert
+            var exception = Assert.Throws<UnauthorizedAccessException>(() =>
+                SolutionAnalyzer.AnalyzeAndExportSolution(invalidPath, verbose, format));
+
+            Assert.Contains("Access to the path '' is denied.", exception.Message);
+        }
+
+        [Fact]
         public void PerformAnalysis_ShouldReturnCorrectAnalysisResult()
         {
             // Arrange
@@ -106,7 +140,7 @@ namespace CodeLineCounter.Tests.Services
                 SolutionAnalyzer.OutputDetailedMetrics(metrics, projectTotals);
 
                 // Assert
-                var expectedOutput = 
+                var expectedOutput =
                     $"Project Project1 (/path/to/project1) - Namespace Namespace1 in file File1.cs (/path/to/project1/File1.cs) has 100 lines of code and a cyclomatic complexity of 10.{Environment.NewLine}" +
                     $"Project Project2 (/path/to/project2) - Namespace Namespace2 in file File2.cs (/path/to/project2/File2.cs) has 200 lines of code and a cyclomatic complexity of 20.{Environment.NewLine}" +
                     $"Project Project1 has 100 total lines of code.{Environment.NewLine}" +
@@ -116,39 +150,39 @@ namespace CodeLineCounter.Tests.Services
             }
         }
 
-            // Export metrics, duplications and dependencies data in parallel for valid input
-[Fact]
-public void export_results_with_valid_input_exports_all_files()
-{
-    // Arrange
-    var result = new AnalysisResult
-    {
-        SolutionFileName = "TestSolution",
-        Metrics = new List<NamespaceMetrics>(),
-        ProjectTotals = new Dictionary<string, int >(),
-        TotalLines = 1000,
-        DuplicationMap = new List<DuplicationCode>(),
-        DependencyList = new List<DependencyRelation>()
-    };
+        // Export metrics, duplications and dependencies data in parallel for valid input
+        [Fact]
+        public void export_results_with_valid_input_exports_all_files()
+        {
+            // Arrange
+            var result = new AnalysisResult
+            {
+                SolutionFileName = "TestSolution",
+                Metrics = new List<NamespaceMetrics>(),
+                ProjectTotals = new Dictionary<string, int>(),
+                TotalLines = 1000,
+                DuplicationMap = new List<DuplicationCode>(),
+                DependencyList = new List<DependencyRelation>()
+            };
 
-    var basePath = FileUtils.GetBasePath();
-    var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
+            var basePath = FileUtils.GetBasePath();
+            var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
 
-    solutionPath = Path.Combine(solutionPath, "TestSolution.sln"); 
-    var format = CoreUtils.ExportFormat.CSV;
+            solutionPath = Path.Combine(solutionPath, "TestSolution.sln");
+            var format = CoreUtils.ExportFormat.CSV;
 
-    // Act
-    using (var sw = new StringWriter())
-    {
-        Console.SetOut(sw);
-        SolutionAnalyzer.ExportResults(result, solutionPath, format);
-    }
+            // Act
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                SolutionAnalyzer.ExportResults(result, solutionPath, format);
+            }
 
-    // Assert
-    Assert.True(File.Exists("TestSolution-CodeMetrics.csv"));
-    Assert.True(File.Exists("TestSolution-CodeDuplications.csv")); 
-    Assert.True(File.Exists("TestSolution-CodeDependencies.csv"));
-}
+            // Assert
+            Assert.True(File.Exists("TestSolution-CodeMetrics.csv"));
+            Assert.True(File.Exists("TestSolution-CodeDuplications.csv"));
+            Assert.True(File.Exists("TestSolution-CodeDependencies.csv"));
+        }
 
     }
 }

--- a/CodeLineCounter/Services/DependencyGraphGenerator.cs
+++ b/CodeLineCounter/Services/DependencyGraphGenerator.cs
@@ -10,7 +10,7 @@ namespace CodeLineCounter.Services
 {
     public static class DependencyGraphGenerator
     {
-        public static async Task GenerateGraph(List<DependencyRelation> dependencies, string outputPath, string? filterNamespace = null, string? filterAssembly = null)
+        public static DotGraph GenerateGraphOnly(List<DependencyRelation> dependencies, string? filterNamespace = null, string? filterAssembly = null)
         {
             var filteredDependencies = dependencies;
             filteredDependencies = FilterNamespaceFromDependencies(dependencies, filterNamespace, filteredDependencies);
@@ -51,7 +51,7 @@ namespace CodeLineCounter.Services
                 graph.Elements.Add(edge);
             }
 
-            await CompileGraphAndWriteToFile(outputPath, graph);
+            return graph;
         }
 
         private static DotEdge CreateEdge(DependencyRelation dep)
@@ -80,7 +80,7 @@ namespace CodeLineCounter.Services
             return cluster;
         }
 
-        private static DotNode CreateNode(Dictionary<string, (int incoming, int outgoing)> vertexInfo, string vertex)
+        public static DotNode CreateNode(Dictionary<string, (int incoming, int outgoing)> vertexInfo, string vertex)
         {
             var info = vertexInfo[vertex];
             var node = new DotNode();
@@ -142,7 +142,7 @@ namespace CodeLineCounter.Services
             }
         }
 
-        private static async Task CompileGraphAndWriteToFile(string outputPath, DotGraph graph)
+        public static async Task CompileGraphAndWriteToFile(string outputPath, DotGraph graph)
         {
             await using var writer = new StringWriter();
             var options = new CompilationOptions

--- a/CodeLineCounter/Utils/DataExporter.cs
+++ b/CodeLineCounter/Utils/DataExporter.cs
@@ -14,11 +14,6 @@ namespace CodeLineCounter.Utils
             { CoreUtils.ExportFormat.JSON, new JsonExportStrategy() }
         };
 
-        public static  Dictionary<CoreUtils.ExportFormat, IExportStrategy> ExportStrategies
-        {
-            get { return _exportStrategies; }
-        }
-
         public static void Export<T>(string filePath, T data, CoreUtils.ExportFormat format) where T : class
         {
             ArgumentNullException.ThrowIfNull(data);

--- a/CodeLineCounter/Utils/DataExporter.cs
+++ b/CodeLineCounter/Utils/DataExporter.cs
@@ -1,5 +1,6 @@
 using CodeLineCounter.Models;
 using CodeLineCounter.Services;
+using DotNetGraph.Core;
 
 
 namespace CodeLineCounter.Utils
@@ -13,6 +14,11 @@ namespace CodeLineCounter.Utils
             { CoreUtils.ExportFormat.JSON, new JsonExportStrategy() }
         };
 
+        public static  Dictionary<CoreUtils.ExportFormat, IExportStrategy> ExportStrategies
+        {
+            get { return _exportStrategies; }
+        }
+
         public static void Export<T>(string filePath, T data, CoreUtils.ExportFormat format) where T : class
         {
             ArgumentNullException.ThrowIfNull(data);
@@ -20,7 +26,7 @@ namespace CodeLineCounter.Utils
             ExportCollection(filePath, [data], format);
         }
 
-        public static void ExportCollection<T>(string filePath, IEnumerable<T> data, CoreUtils.ExportFormat format) where T : class
+        public static void ExportCollection<T>(string? filePath, IEnumerable<T> data, CoreUtils.ExportFormat format) where T : class
         {
             if (string.IsNullOrEmpty(filePath))
                 throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
@@ -48,7 +54,8 @@ namespace CodeLineCounter.Utils
             string outputFilePath = CoreUtils.GetExportFileNameWithExtension(filePath, format);
             ExportCollection(outputFilePath, dependencies, format);
 
-            await DependencyGraphGenerator.GenerateGraph(dependencies, Path.ChangeExtension(outputFilePath, ".dot"));
+            DotGraph graph =  DependencyGraphGenerator.GenerateGraphOnly(dependencies);
+            await DependencyGraphGenerator.CompileGraphAndWriteToFile(Path.ChangeExtension(outputFilePath, ".dot"), graph);
         }
 
         public static void ExportMetrics(string filePath, List<NamespaceMetrics> metrics,


### PR DESCRIPTION
Introduce the Moq package to improve testing capabilities and enhance tests for `DependencyGraphGenerator` and `DataExporter`. Add a launch configuration for `CodeLineCounter` in VSCode.