### PR TITLE
Feat add output path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /codeql*
 /*.dot
 /*snyk*
+/exports
 
 # Mac OS
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,16 @@
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole"
+        },
+        {
+            "name": "C#: CodeLineCounter - withOutputPath",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/CodeLineCounter/bin/Debug/net9.0/CodeLineCounter.dll",
+            "args": ["-d", "${workspaceFolder}", "-output", "${workspaceFolder}\\exports" ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
         }
     ]
 }

--- a/CodeLineCounter.Tests/CodeAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/CodeAnalyzerTests.cs
@@ -9,6 +9,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void TestAnalyzeSolution()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             string basePath = FileUtils.GetBasePath();
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", "..", "CodeLineCounter.sln"));
 
@@ -28,6 +31,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void AnalyzeSourceCode_Should_Set_CurrentNamespace()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             var projectNamespaceMetrics = new Dictionary<string, int>();
             var lines = new string[]
@@ -48,6 +54,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void AnalyzeSourceCode_Should_Set_FileLineCount()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             var projectNamespaceMetrics = new Dictionary<string, int>();
             var lines = new string[]
@@ -68,6 +77,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void AnalyzeSourceCode_Should_Set_FileCyclomaticComplexity()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+            
             // Arrange
             var projectNamespaceMetrics = new Dictionary<string, int>();
             var lines = new string[]

--- a/CodeLineCounter.Tests/CodeAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/CodeAnalyzerTests.cs
@@ -31,70 +31,80 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void AnalyzeSourceCode_Should_Set_CurrentNamespace()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-
-            // Arrange
-            var projectNamespaceMetrics = new Dictionary<string, int>();
-            var lines = new string[]
+            using (StringWriter consoleOutput = new())
             {
+                Console.SetOut(consoleOutput);
+
+                // Arrange
+                var projectNamespaceMetrics = new Dictionary<string, int>();
+                var lines = new string[]
+                {
                 "namespace MyNamespace",
                 "{",
                 "    // Code goes here",
                 "}"
-            };
+                };
 
-            // Act
-            CodeMetricsAnalyzer.AnalyzeSourceCode(projectNamespaceMetrics, lines, out string? currentNamespace, out _, out _);
+                // Act
+                CodeMetricsAnalyzer.AnalyzeSourceCode(projectNamespaceMetrics, lines, out string? currentNamespace, out _, out _);
 
-            // Assert
-            Assert.Equal("MyNamespace", currentNamespace);
+                // Assert
+                Assert.Equal("MyNamespace", currentNamespace);
+
+            }
+
         }
 
         [Fact]
         public void AnalyzeSourceCode_Should_Set_FileLineCount()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-
-            // Arrange
-            var projectNamespaceMetrics = new Dictionary<string, int>();
-            var lines = new string[]
+            using (StringWriter consoleOutput = new())
             {
+                Console.SetOut(consoleOutput);
+
+                // Arrange
+                var projectNamespaceMetrics = new Dictionary<string, int>();
+                var lines = new string[]
+                {
                 "namespace MyNamespace",
                 "{",
                 "    // Code goes here",
                 "}"
-            };
+                };
 
-            // Act
-            CodeMetricsAnalyzer.AnalyzeSourceCode(projectNamespaceMetrics, lines, out _, out int fileLineCount, out _);
+                // Act
+                CodeMetricsAnalyzer.AnalyzeSourceCode(projectNamespaceMetrics, lines, out _, out int fileLineCount, out _);
 
-            // Assert - 3 lines only because comment lines are ignored
-            Assert.Equal(3, fileLineCount);
+                // Assert - 3 lines only because comment lines are ignored
+                Assert.Equal(3, fileLineCount);
+            }
+
         }
 
         [Fact]
         public void AnalyzeSourceCode_Should_Set_FileCyclomaticComplexity()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-            
-            // Arrange
-            var projectNamespaceMetrics = new Dictionary<string, int>();
-            var lines = new string[]
+            using (StringWriter consoleOutput = new())
             {
+                Console.SetOut(consoleOutput);
+
+                // Arrange
+                var projectNamespaceMetrics = new Dictionary<string, int>();
+                var lines = new string[]
+                {
                 "namespace MyNamespace",
                 "{",
                 "    // Code goes here",
                 "}"
-            };
+                };
 
-            // Act
-            CodeMetricsAnalyzer.AnalyzeSourceCode(projectNamespaceMetrics, lines, out _, out _, out int fileCyclomaticComplexity);
+                // Act
+                CodeMetricsAnalyzer.AnalyzeSourceCode(projectNamespaceMetrics, lines, out _, out _, out int fileCyclomaticComplexity);
 
-            // Assert
-            Assert.Equal(1, fileCyclomaticComplexity);
+                // Assert
+                Assert.Equal(1, fileCyclomaticComplexity);
+            }
+
         }
 
         [Fact]

--- a/CodeLineCounter.Tests/CodeDuplicationCheckerTests.cs
+++ b/CodeLineCounter.Tests/CodeDuplicationCheckerTests.cs
@@ -2,7 +2,7 @@ using CodeLineCounter.Services;
 
 namespace CodeLineCounter.Tests
 {
-    public class CodeDuplicationCheckerTests  : IDisposable
+    public class CodeDuplicationCheckerTests : IDisposable
     {
         private readonly string _testDirectory;
         private bool _disposed;
@@ -12,13 +12,13 @@ namespace CodeLineCounter.Tests
             _testDirectory = Path.Combine(Path.GetTempPath(), "CodeDuplicationCheckerTests");
             Directory.CreateDirectory(_testDirectory);
         }
-        
+
         [Fact]
         public void DetectCodeDuplicationInFiles_ShouldDetectDuplicates()
         {
             using StringWriter consoleOutput = new();
             Console.SetOut(consoleOutput);
-            
+
             // Arrange
             var file1 = Path.Combine(_testDirectory, "TestFile1.cs");
             var file2 = Path.Combine(_testDirectory, "TestFile2.cs");
@@ -70,13 +70,14 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void DetectCodeDuplicationInSourceCode_ShouldDetectDuplicates()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Arrange
-            var checker = new CodeDuplicationChecker();
+                // Arrange
+                var checker = new CodeDuplicationChecker();
 
-            var sourceCode1 = @"
+                var sourceCode1 = @"
                 public class TestClass
                 {
                     public void TestMethod()
@@ -88,7 +89,7 @@ namespace CodeLineCounter.Tests
                     }
                 }";
 
-            var sourceCode2 = @"
+                var sourceCode2 = @"
                 public class AnotherTestClass
                 {
                     public void AnotherTestMethod()
@@ -100,30 +101,33 @@ namespace CodeLineCounter.Tests
                     }
                 }";
 
-            var file1 = Path.Combine(_testDirectory, "TestFile3.cs");
-            var file2 = Path.Combine(_testDirectory, "TestFile4.cs");
+                var file1 = Path.Combine(_testDirectory, "TestFile3.cs");
+                var file2 = Path.Combine(_testDirectory, "TestFile4.cs");
 
-            // Act
-            checker.DetectCodeDuplicationInSourceCode(file1, sourceCode1);
-            checker.DetectCodeDuplicationInSourceCode(file2, sourceCode2);
-            var result = checker.GetCodeDuplicationMap();
+                // Act
+                checker.DetectCodeDuplicationInSourceCode(file1, sourceCode1);
+                checker.DetectCodeDuplicationInSourceCode(file2, sourceCode2);
+                var result = checker.GetCodeDuplicationMap();
 
-            // Assert
-            Assert.NotEmpty(result);
-            var duplicateEntry = result.First();
-            Assert.Equal(2, duplicateEntry.Value.Count); // Both methods should be detected as duplicates
+                // Assert
+                Assert.NotEmpty(result);
+                var duplicateEntry = result.First();
+                Assert.Equal(2, duplicateEntry.Value.Count); // Both methods should be detected as duplicates
+            }
+
         }
 
         [Fact]
         public void DetectCodeDuplicationInSourceCode_ShouldNotDetectDuplicatesForDifferentCode()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Arrange
-            var checker = new CodeDuplicationChecker();
+                // Arrange
+                var checker = new CodeDuplicationChecker();
 
-            var sourceCode1 = @"
+                var sourceCode1 = @"
                 public class TestClass
                 {
                     public void TestMethod()
@@ -135,7 +139,7 @@ namespace CodeLineCounter.Tests
                     }
                 }";
 
-            var sourceCode2 = @"
+                var sourceCode2 = @"
                 public class AnotherTestClass
                 {
                     public void AnotherTestMethod()
@@ -144,19 +148,21 @@ namespace CodeLineCounter.Tests
                     }
                 }";
 
-            var file1 = Path.Combine(_testDirectory, "TestFile5.cs");
-            var file2 = Path.Combine(_testDirectory, "TestFile6.cs");
+                var file1 = Path.Combine(_testDirectory, "TestFile5.cs");
+                var file2 = Path.Combine(_testDirectory, "TestFile6.cs");
 
-            // Act
-            checker.DetectCodeDuplicationInSourceCode(file1, sourceCode1);
-            checker.DetectCodeDuplicationInSourceCode(file2, sourceCode2);
-            var result = checker.GetCodeDuplicationMap();
+                // Act
+                checker.DetectCodeDuplicationInSourceCode(file1, sourceCode1);
+                checker.DetectCodeDuplicationInSourceCode(file2, sourceCode2);
+                var result = checker.GetCodeDuplicationMap();
 
-            // Assert
-            Assert.Empty(result); // No duplicates should be detected
+                // Assert
+                Assert.Empty(result); // No duplicates should be detected
+            }
+
         }
 
-         protected virtual void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
             {

--- a/CodeLineCounter.Tests/CodeDuplicationCheckerTests.cs
+++ b/CodeLineCounter.Tests/CodeDuplicationCheckerTests.cs
@@ -16,6 +16,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void DetectCodeDuplicationInFiles_ShouldDetectDuplicates()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+            
             // Arrange
             var file1 = Path.Combine(_testDirectory, "TestFile1.cs");
             var file2 = Path.Combine(_testDirectory, "TestFile2.cs");
@@ -67,6 +70,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void DetectCodeDuplicationInSourceCode_ShouldDetectDuplicates()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             var checker = new CodeDuplicationChecker();
 
@@ -111,6 +117,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void DetectCodeDuplicationInSourceCode_ShouldNotDetectDuplicatesForDifferentCode()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             var checker = new CodeDuplicationChecker();
 

--- a/CodeLineCounter.Tests/CodeDuplicationCheckerTests.cs
+++ b/CodeLineCounter.Tests/CodeDuplicationCheckerTests.cs
@@ -2,14 +2,23 @@ using CodeLineCounter.Services;
 
 namespace CodeLineCounter.Tests
 {
-    public class CodeDuplicationCheckerTests
+    public class CodeDuplicationCheckerTests  : IDisposable
     {
+        private readonly string _testDirectory;
+        private bool _disposed;
+
+        public CodeDuplicationCheckerTests()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "CodeDuplicationCheckerTests");
+            Directory.CreateDirectory(_testDirectory);
+        }
+        
         [Fact]
         public void DetectCodeDuplicationInFiles_ShouldDetectDuplicates()
         {
             // Arrange
-            var file1 = "TestFile1.cs";
-            var file2 = "TestFile2.cs";
+            var file1 = Path.Combine(_testDirectory, "TestFile1.cs");
+            var file2 = Path.Combine(_testDirectory, "TestFile2.cs");
 
             var code1 = @"
                 public class TestClass
@@ -85,8 +94,8 @@ namespace CodeLineCounter.Tests
                     }
                 }";
 
-            var file1 = "TestFile3.cs";
-            var file2 = "TestFile4.cs";
+            var file1 = Path.Combine(_testDirectory, "TestFile3.cs");
+            var file2 = Path.Combine(_testDirectory, "TestFile4.cs");
 
             // Act
             checker.DetectCodeDuplicationInSourceCode(file1, sourceCode1);
@@ -126,8 +135,8 @@ namespace CodeLineCounter.Tests
                     }
                 }";
 
-            var file1 = "TestFile5.cs";
-            var file2 = "TestFile6.cs";
+            var file1 = Path.Combine(_testDirectory, "TestFile5.cs");
+            var file2 = Path.Combine(_testDirectory, "TestFile6.cs");
 
             // Act
             checker.DetectCodeDuplicationInSourceCode(file1, sourceCode1);
@@ -136,6 +145,33 @@ namespace CodeLineCounter.Tests
 
             // Assert
             Assert.Empty(result); // No duplicates should be detected
+        }
+
+         protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing && Directory.Exists(_testDirectory))
+                {
+                    // Dispose managed resources
+                    Directory.Delete(_testDirectory, true);
+                }
+
+                // Dispose unmanaged resources (if any)
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~CodeDuplicationCheckerTests()
+        {
+            Dispose(false);
         }
     }
 }

--- a/CodeLineCounter.Tests/CoreUtilsTests.cs
+++ b/CodeLineCounter.Tests/CoreUtilsTests.cs
@@ -131,7 +131,7 @@ namespace CodeLineCounter.Tests
                 result = CoreUtils.ParseArguments(args);
                 sortieConsole = sw.ToString();
                 Assert.Equal(CoreUtils.ExportFormat.CSV, result.Format);
-                Assert.Contains("Invalid format", sortieConsole.ToString());
+                Assert.Contains("Invalid format", sortieConsole);
             }
 
         }
@@ -160,16 +160,20 @@ namespace CodeLineCounter.Tests
             // Arrange
             int solutionCount = 5;
             string input = "6";
-            using var inputStream = new StringReader(input);
-            using var consoleOutput = new StringWriter();
-            Console.SetOut(consoleOutput);
-            Console.SetIn(inputStream);
+            using (var inputStream = new StringReader(input))
+            {
+                using (var consoleOutput = new StringWriter())
+                {
+                    Console.SetOut(consoleOutput);
+                    Console.SetIn(inputStream);
 
-            // Act
-            int result = CoreUtils.GetUserChoice(solutionCount);
+                    // Act
+                    int result = CoreUtils.GetUserChoice(solutionCount);
 
-            // Assert
-            Assert.Equal(-1, result);
+                    // Assert
+                    Assert.Equal(-1, result);
+                }
+            }
         }
 
         [Fact]
@@ -178,16 +182,22 @@ namespace CodeLineCounter.Tests
             // Arrange
             int solutionCount = 5;
             string input = "invalid";
-            using var inputStream = new StringReader(input);
-            using var consoleOutput = new StringWriter();
-            Console.SetOut(consoleOutput);
-            Console.SetIn(inputStream);
+            using (var inputStream = new StringReader(input))
+            {
+                using (var consoleOutput = new StringWriter())
+                {
+                    Console.SetOut(consoleOutput);
+                    Console.SetIn(inputStream);
 
-            // Act
-            int result = CoreUtils.GetUserChoice(solutionCount);
+                    // Act
+                    int result = CoreUtils.GetUserChoice(solutionCount);
 
-            // Assert
-            Assert.Equal(-1, result);
+                    // Assert
+                    Assert.Equal(-1, result);
+                }
+
+            }
+
         }
 
         // GetUserChoice returns valid selection when input is within range
@@ -196,16 +206,22 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             var input = "2";
-            using var consoleInput = new StringReader(input);
-            using var consoleOutput = new StringWriter();
-            Console.SetOut(consoleOutput);
-            Console.SetIn(consoleInput);
+            using (var consoleInput = new StringReader(input))
+            {
+                using (var consoleOutput = new StringWriter())
+                {
+                    Console.SetOut(consoleOutput);
+                    Console.SetIn(consoleInput);
 
-            // Act
-            int result = CoreUtils.GetUserChoice(3);
+                    // Act
+                    int result = CoreUtils.GetUserChoice(3);
 
-            // Assert
-            Assert.Equal(2, result);
+                    // Assert
+                    Assert.Equal(2, result);
+                }
+
+            }
+
         }
 
         [Theory]
@@ -215,16 +231,22 @@ namespace CodeLineCounter.Tests
         public void GetUserChoice_handles_invalid_input(string input)
         {
             // Arrange
-            using var consoleInput = new StringReader(input);
-            using var consoleOutput = new StringWriter();
-            Console.SetOut(consoleOutput);
-            Console.SetIn(consoleInput);
+            using (var consoleInput = new StringReader(input))
+            {
+                using (var consoleOutput = new StringWriter())
+                {
+                    Console.SetOut(consoleOutput);
+                    Console.SetIn(consoleInput);
 
-            // Act
-            int result = CoreUtils.GetUserChoice(5);
+                    // Act
+                    int result = CoreUtils.GetUserChoice(5);
 
-            // Assert
-            Assert.Equal(-1, result);
+                    // Assert
+                    Assert.Equal(-1, result);
+                }
+            }
+
+
         }
 
         [Fact]
@@ -241,45 +263,51 @@ namespace CodeLineCounter.Tests
             ];
 
             // Redirect console output to a StringWriter
-            using StringWriter sw = new();
-            Console.SetOut(sw);
-
-            // Act
-            CoreUtils.DisplaySolutions(solutionFiles);
-
-            // Assert
-            string expectedOutput = $"Available solutions:{envNewLine}";
-            for (int i = 0; i < solutionFiles.Count; i++)
+            using (StringWriter sw = new())
             {
-                expectedOutput += $"{i + 1}. {solutionFiles[i]}{envNewLine}";
+                Console.SetOut(sw);
+
+                // Act
+                CoreUtils.DisplaySolutions(solutionFiles);
+
+                // Assert
+                string expectedOutput = $"Available solutions:{envNewLine}";
+                for (int i = 0; i < solutionFiles.Count; i++)
+                {
+                    expectedOutput += $"{i + 1}. {solutionFiles[i]}{envNewLine}";
+                }
+                Assert.Equal(expectedOutput, sw.ToString());
             }
-            Assert.Equal(expectedOutput, sw.ToString());
+
         }
 
         [Fact]
         public void GetFilenamesList_Should_Return_List_Of_Filenames()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            List<string> solutionFiles =
-            [
-                "Solution1.sln",
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                List<string> solutionFiles =
+                [
+                    "Solution1.sln",
                 "Solution2.sln",
                 "Solution3.sln"
-            ];
+                ];
 
-            // Act
-            List<string> result = CoreUtils.GetFilenamesList(solutionFiles);
+                // Act
+                List<string> result = CoreUtils.GetFilenamesList(solutionFiles);
 
-            // Assert
-            List<string> expectedFilenames =
-            [
-                "Solution1.sln",
+                // Assert
+                List<string> expectedFilenames =
+                [
+                    "Solution1.sln",
                 "Solution2.sln",
                 "Solution3.sln"
-            ];
-            Assert.Equal(expectedFilenames, result);
+                ];
+                Assert.Equal(expectedFilenames, result);
+            }
+
         }
 
 
@@ -288,15 +316,18 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             Settings settings = new Settings(true, null, ".", true, CoreUtils.ExportFormat.JSON);
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
 
-            // Act
-            var result = settings.IsValid();
+                // Act
+                var result = settings.IsValid();
 
-            // Assert
-            Assert.True(result);
-            Assert.Contains("Usage:", sw.ToString());
+                // Assert
+                Assert.True(result);
+                Assert.Contains("Usage:", sw.ToString());
+            }
+
         }
 
         [Fact]
@@ -304,44 +335,53 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             Settings settings = new Settings(verbose: false, directoryPath: null, help: false, format: CoreUtils.ExportFormat.CSV);
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
 
-            // Act
-            var result = settings.IsValid();
+                // Act
+                var result = settings.IsValid();
 
-            // Assert
-            Assert.False(result);
-            Assert.Contains("Please provide the directory path", sw.ToString());
+                // Assert
+                Assert.False(result);
+                Assert.Contains("Please provide the directory path", sw.ToString());
+            }
+
         }
 
         [Fact]
         public void CheckSettings_WhenSettingsAreValid_ReturnsTrue()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            Settings settings = new Settings(false, "some_directory", false, CoreUtils.ExportFormat.CSV);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                Settings settings = new Settings(false, "some_directory", false, CoreUtils.ExportFormat.CSV);
 
-            // Act
-            var result = settings.IsValid();
+                // Act
+                var result = settings.IsValid();
 
-            // Assert
-            Assert.True(result);
+                // Assert
+                Assert.True(result);
+            }
+
         }
         [Fact]
         public void CheckSettings_WhenSettingsOutputIsInValid_ReturnsFalse()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            Settings settings = new Settings(false, "some_directory", "invalid_output_path", false, CoreUtils.ExportFormat.CSV);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                Settings settings = new Settings(false, "some_directory", "invalid_output_path", false, CoreUtils.ExportFormat.CSV);
 
-            // Act
-            var result = settings.IsValid();
+                // Act
+                var result = settings.IsValid();
 
-            // Assert
-            Assert.True(result);
+                // Assert
+                Assert.True(result);
+            }
+
         }
 
         [Fact]
@@ -349,14 +389,17 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             Settings settings = new Settings(false, null, false, CoreUtils.ExportFormat.CSV);
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
 
-            // Act
-            var result = settings.IsValid();
+                // Act
+                var result = settings.IsValid();
 
-            // Assert
-            Assert.False(result);
+                // Assert
+                Assert.False(result);
+            }
+
         }
 
         [Theory]
@@ -367,61 +410,70 @@ namespace CodeLineCounter.Tests
         [InlineData("metrics_789.csv", CoreUtils.ExportFormat.CSV)]
         public void get_export_file_name_with_extension_handles_alphanumeric(string fileName, CoreUtils.ExportFormat format)
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Act
-            var fullFileName = Path.Combine(_testDirectory, fileName);
-            var result = CoreUtils.GetExportFileNameWithExtension(fullFileName, format);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Act
+                var fullFileName = Path.Combine(_testDirectory, fileName);
+                var result = CoreUtils.GetExportFileNameWithExtension(fullFileName, format);
 
-            // Assert
-            Assert.Contains(Path.GetFileNameWithoutExtension(fullFileName), result);
-            Assert.True(File.Exists(result) || !File.Exists(result));
+                // Assert
+                Assert.Contains(Path.GetFileNameWithoutExtension(fullFileName), result);
+                Assert.True(File.Exists(result) || !File.Exists(result));
+            }
+
         }
 
         // Returns list of filenames for existing files in input list
         [Fact]
         public void get_filenames_list_returns_filenames_for_existing_files()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var testFiles = new List<string>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                var testFiles = new List<string>
             {
                 Path.Combine(_testDirectory, "file1.txt"),
                 Path.Combine(_testDirectory, "file2.txt")
             };
 
-            File.WriteAllText(testFiles[0], "test content");
-            File.WriteAllText(testFiles[1], "test content");
+                File.WriteAllText(testFiles[0], "test content");
+                File.WriteAllText(testFiles[1], "test content");
 
-            // Act
-            var result = CoreUtils.GetFilenamesList(testFiles);
+                // Act
+                var result = CoreUtils.GetFilenamesList(testFiles);
 
-            // Assert
-            Assert.Equal(2, result.Count);
-            Assert.Equal("file1.txt", result[0]);
-            Assert.Equal("file2.txt", result[1]);
+                // Assert
+                Assert.Equal(2, result.Count);
+                Assert.Equal("file1.txt", result[0]);
+                Assert.Equal("file2.txt", result[1]);
 
-            // Cleanup
-            File.Delete(testFiles[0]);
-            File.Delete(testFiles[1]);
+                // Cleanup
+                File.Delete(testFiles[0]);
+                File.Delete(testFiles[1]);
+            }
+
         }
 
         // Directory creation succeeds when OutputPath is valid and does not exist
         [Fact]
         public void create_directory_succeeds_with_valid_path()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var settings = new Settings();
-            settings.DirectoryPath = _testDirectory;
-            settings.OutputPath = Path.Combine(_testDirectory, "TestOutput");
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var settings = new Settings();
+                settings.DirectoryPath = _testDirectory;
+                settings.OutputPath = Path.Combine(_testDirectory, "TestOutput");
 
-            var result = settings.IsValid();
+                var result = settings.IsValid();
 
-            Assert.True(result);
-            Assert.True(Directory.Exists(settings.OutputPath));
-            Directory.Delete(settings.OutputPath);
+                Assert.True(result);
+                Assert.True(Directory.Exists(settings.OutputPath));
+                Directory.Delete(settings.OutputPath);
+            }
+
         }
 
         protected virtual void Dispose(bool disposing)

--- a/CodeLineCounter.Tests/CoreUtilsTests.cs
+++ b/CodeLineCounter.Tests/CoreUtilsTests.cs
@@ -130,12 +130,9 @@ namespace CodeLineCounter.Tests
                 Console.SetOut(sw);
                 result = CoreUtils.ParseArguments(args);
                 sortieConsole = sw.ToString();
+                Assert.Equal(CoreUtils.ExportFormat.CSV, result.Format);
+                Assert.Contains("Invalid format", sortieConsole.ToString());
             }
-
-                        // Assert
-            Assert.Equal(CoreUtils.ExportFormat.CSV, result.Format);
-            Assert.Contains("Invalid format", sortieConsole.ToString());
-
 
         }
 

--- a/CodeLineCounter.Tests/CoreUtilsTests.cs
+++ b/CodeLineCounter.Tests/CoreUtilsTests.cs
@@ -19,6 +19,8 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             string[] args = ["-verbose", "-d", "testDirectory", "-output", _testDirectory];
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
 
             // Act
             Settings settings = CoreUtils.ParseArguments(args);
@@ -33,6 +35,8 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             string[] args = ["-help"];
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
 
             // Act
             var settings = CoreUtils.ParseArguments(args);
@@ -46,6 +50,8 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             string[] args = [];
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
 
             // Act
             var settings = CoreUtils.ParseArguments(args);
@@ -60,6 +66,8 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             string[] args = ["-invalid", "-d", "testDirectory", "-f", "json"];
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
 
             // Act
             var settings = CoreUtils.ParseArguments(args);
@@ -75,6 +83,8 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             string[] args = new[] { "-verbose", "-d", "C:/test", "-format", "JSON", "-help" };
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
 
             // Act
             var result = CoreUtils.ParseArguments(args);
@@ -92,6 +102,8 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             string[] emptyArgs = Array.Empty<string>();
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
 
             // Act
             var result = CoreUtils.ParseArguments(emptyArgs);

--- a/CodeLineCounter.Tests/CoreUtilsTests.cs
+++ b/CodeLineCounter.Tests/CoreUtilsTests.cs
@@ -121,15 +121,22 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             string[] args = new[] { "-format", "INVALID" };
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            Settings result;
+            string sortieConsole;
 
             // Act
-            var result = CoreUtils.ParseArguments(args);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                result = CoreUtils.ParseArguments(args);
+                sortieConsole = sw.ToString();
+            }
 
-            // Assert
+                        // Assert
             Assert.Equal(CoreUtils.ExportFormat.CSV, result.Format);
-            Assert.Contains("Invalid format", consoleOutput.ToString());
+            Assert.Contains("Invalid format", sortieConsole.ToString());
+
+
         }
 
         [Fact]
@@ -226,7 +233,7 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void DisplaySolutions_Should_Write_Solutions_To_Console()
         {
-            
+
             var envNewLine = Environment.NewLine;
             // Arrange
             List<string> solutionFiles =

--- a/CodeLineCounter.Tests/CsvHandlerTests.cs
+++ b/CodeLineCounter.Tests/CsvHandlerTests.cs
@@ -2,12 +2,22 @@ using CodeLineCounter.Utils;
 
 namespace CodeLineCounter.Tests
 {
-    public class CsvHandlerTests
+    public class CsvHandlerTests : IDisposable
     {
+
+        private readonly string _testDirectory;
+        private bool _disposed;
+
         private class TestRecord
         {
             public int Id { get; set; }
             public string? Name { get; set; }
+        }
+
+        public CsvHandlerTests()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "CsvHandlerTests");
+            Directory.CreateDirectory(_testDirectory);
         }
 
         [Fact]
@@ -19,7 +29,7 @@ namespace CodeLineCounter.Tests
                 new() { Id = 1, Name = "Alice" },
                 new() { Id = 2, Name = "Bob" }
             };
-            string filePath = "test_1.csv";
+            string filePath = Path.Combine(_testDirectory,"test_1.csv");
 
             // Act
             CsvHandler.Serialize(data, filePath);
@@ -38,7 +48,7 @@ namespace CodeLineCounter.Tests
         public void Deserialize_ValidFile_ReturnsData()
         {
             // Arrange
-            string filePath = "test_2.csv";
+            string filePath = Path.Combine(_testDirectory,"test_2.csv");
             var data = new List<string>
             {
                 "Id,Name",
@@ -64,7 +74,7 @@ namespace CodeLineCounter.Tests
         {
             // Arrange
             var data = new List<TestRecord>();
-            string filePath = "test_3.csv";
+            string filePath = Path.Combine(_testDirectory,"test_3.csv");
 
             // Act
             CsvHandler.Serialize(data, filePath);
@@ -81,7 +91,7 @@ namespace CodeLineCounter.Tests
         public void Deserialize_EmptyFile_ReturnsEmptyList()
         {
             // Arrange
-            string filePath = "test_4.csv";
+            string filePath = Path.Combine(_testDirectory,"test_4.csv");
             File.WriteAllText(filePath, "Id,Name");
 
             // Act
@@ -92,6 +102,33 @@ namespace CodeLineCounter.Tests
 
             // Cleanup
             File.Delete(filePath);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing && Directory.Exists(_testDirectory))
+                {
+                    // Dispose managed resources
+                    Directory.Delete(_testDirectory, true);
+                }
+
+                // Dispose unmanaged resources (if any)
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~CsvHandlerTests()
+        {
+            Dispose(false);
         }
     }
 }

--- a/CodeLineCounter.Tests/CsvHandlerTests.cs
+++ b/CodeLineCounter.Tests/CsvHandlerTests.cs
@@ -23,97 +23,109 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void Serialize_ValidData_WritesToFile()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Arrange
-            var data = new List<TestRecord>
+                // Arrange
+                var data = new List<TestRecord>
             {
                 new() { Id = 1, Name = "Alice" },
                 new() { Id = 2, Name = "Bob" }
             };
-            string filePath = Path.Combine(_testDirectory,"test_1.csv");
+                string filePath = Path.Combine(_testDirectory, "test_1.csv");
 
-            // Act
-            CsvHandler.Serialize(data, filePath);
+                // Act
+                CsvHandler.Serialize(data, filePath);
 
-            // Assert
-            var lines = File.ReadAllLines(filePath);
-            Assert.Equal(3, lines.Length); // Header + 2 records
-            Assert.Contains("Alice", lines[1]);
-            Assert.Contains("Bob", lines[2]);
+                // Assert
+                var lines = File.ReadAllLines(filePath);
+                Assert.Equal(3, lines.Length); // Header + 2 records
+                Assert.Contains("Alice", lines[1]);
+                Assert.Contains("Bob", lines[2]);
 
-            // Cleanup
-            File.Delete(filePath);
+                // Cleanup
+                File.Delete(filePath);
+            }
+
         }
 
         [Fact]
         public void Deserialize_ValidFile_ReturnsData()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-
-            // Arrange
-            string filePath = Path.Combine(_testDirectory,"test_2.csv");
-            var data = new List<string>
+            using (StringWriter consoleOutput = new())
             {
-                "Id,Name",
-                "1,Alice",
-                "2,Bob"
-            };
-            File.WriteAllLines(filePath, data);
+                Console.SetOut(consoleOutput);
 
-            // Act
-            var result = CsvHandler.Deserialize<TestRecord>(filePath).ToList();
+                // Arrange
+                string filePath = Path.Combine(_testDirectory, "test_2.csv");
+                var data = new List<string>
+                {
+                    "Id,Name",
+                    "1,Alice",
+                    "2,Bob"
+                };
+                File.WriteAllLines(filePath, data);
 
-            // Assert
-            Assert.Equal(2, result.Count);
-            Assert.Equal("Alice", result[0].Name);
-            Assert.Equal("Bob", result[1].Name);
+                // Act
+                var result = CsvHandler.Deserialize<TestRecord>(filePath).ToList();
 
-            // Cleanup
-            File.Delete(filePath);
+                // Assert
+                Assert.Equal(2, result.Count);
+                Assert.Equal("Alice", result[0].Name);
+                Assert.Equal("Bob", result[1].Name);
+
+                // Cleanup
+                File.Delete(filePath);
+            }
+
         }
 
         [Fact]
         public void Serialize_EmptyData_WritesEmptyFile()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Arrange
-            var data = new List<TestRecord>();
-            string filePath = Path.Combine(_testDirectory,"test_3.csv");
+                // Arrange
+                var data = new List<TestRecord>();
+                string filePath = Path.Combine(_testDirectory, "test_3.csv");
 
-            // Act
-            CsvHandler.Serialize(data, filePath);
+                // Act
+                CsvHandler.Serialize(data, filePath);
 
-            // Assert
-            var lines = File.ReadAllLines(filePath);
-            Assert.Single(lines); // Only header
+                // Assert
+                var lines = File.ReadAllLines(filePath);
+                Assert.Single(lines); // Only header
 
-            // Cleanup
-            File.Delete(filePath);
+                // Cleanup
+                File.Delete(filePath);
+            }
+
         }
 
         [Fact]
         public void Deserialize_EmptyFile_ReturnsEmptyList()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-            
-            // Arrange
-            string filePath = Path.Combine(_testDirectory,"test_4.csv");
-            File.WriteAllText(filePath, "Id,Name");
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Act
-            var result = CsvHandler.Deserialize<TestRecord>(filePath).ToList();
+                // Arrange
+                string filePath = Path.Combine(_testDirectory, "test_4.csv");
+                File.WriteAllText(filePath, "Id,Name");
 
-            // Assert
-            Assert.Empty(result);
+                // Act
+                var result = CsvHandler.Deserialize<TestRecord>(filePath).ToList();
 
-            // Cleanup
-            File.Delete(filePath);
+                // Assert
+                Assert.Empty(result);
+
+                // Cleanup
+                File.Delete(filePath);
+            }
+
         }
 
         protected virtual void Dispose(bool disposing)

--- a/CodeLineCounter.Tests/CsvHandlerTests.cs
+++ b/CodeLineCounter.Tests/CsvHandlerTests.cs
@@ -23,6 +23,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void Serialize_ValidData_WritesToFile()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             var data = new List<TestRecord>
             {
@@ -47,6 +50,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void Deserialize_ValidFile_ReturnsData()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             string filePath = Path.Combine(_testDirectory,"test_2.csv");
             var data = new List<string>
@@ -72,6 +78,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void Serialize_EmptyData_WritesEmptyFile()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             var data = new List<TestRecord>();
             string filePath = Path.Combine(_testDirectory,"test_3.csv");
@@ -90,6 +99,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void Deserialize_EmptyFile_ReturnsEmptyList()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+            
             // Arrange
             string filePath = Path.Combine(_testDirectory,"test_4.csv");
             File.WriteAllText(filePath, "Id,Name");

--- a/CodeLineCounter.Tests/CyclomaticComplexityCalculatorTests.cs
+++ b/CodeLineCounter.Tests/CyclomaticComplexityCalculatorTests.cs
@@ -9,10 +9,11 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void TestCalculateComplexity()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var code = @"
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                var code = @"
                     public class TestClass
                     {
                         public void TestMethod()
@@ -21,23 +22,26 @@ namespace CodeLineCounter.Tests
                             for (int i = 0; i < 10; i++) {}
                         }
                     }
-            ";
-            var tree = CSharpSyntaxTree.ParseText(code);
+                ";
+                var tree = CSharpSyntaxTree.ParseText(code);
 
-            // Act
-            var complexity = CyclomaticComplexityCalculator.Calculate(tree.GetRoot());
+                // Act
+                var complexity = CyclomaticComplexityCalculator.Calculate(tree.GetRoot());
 
-            // Assert
-            Assert.Equal(3, complexity); // 1 (default) + 1 (if) + 1 (for)
+                // Assert
+                Assert.Equal(3, complexity); // 1 (default) + 1 (if) + 1 (for)
+            }
+
         }
 
         [Fact]
         public void Calculate_Should_Return_Correct_Complexity()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                var syntaxTree = CSharpSyntaxTree.ParseText(@"
                 public class MyClass
                 {
                     public void MyMethod()
@@ -52,56 +56,61 @@ namespace CodeLineCounter.Tests
                         }
                     }
                 }
-            ");
-            var root = syntaxTree.GetRoot();
-            var methodDeclaration = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+                ");
+                var root = syntaxTree.GetRoot();
+                var methodDeclaration = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
 
-            // Act
-            var complexity = CyclomaticComplexityCalculator.Calculate(methodDeclaration);
+                // Act
+                var complexity = CyclomaticComplexityCalculator.Calculate(methodDeclaration);
 
-            // Assert
-            Assert.Equal(3, complexity);
+                // Assert
+                Assert.Equal(3, complexity);
+            }
+
         }
 
         [Fact]
-         public void Calculate_Should_Return_Correct_Complexity_6()
+        public void Calculate_Should_Return_Correct_Complexity_6()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"
-            class Program
+            using (var sw = new StringWriter())
             {
-                static void Main(string[] args)
+                Console.SetOut(sw);
+                // Arrange
+                var syntaxTree = CSharpSyntaxTree.ParseText(@"
+                class Program
                 {
-                    int x = 5;
-
-                    switch (x)
+                    static void Main(string[] args)
                     {
-                    case 1:
-                    Console.WriteLine(1);
-                    break;
-                    case 2:
-                    Console.WriteLine(2);  
-                    break;
-                    case 3:
-                    Console.WriteLine(3);
-                    break;
-                    case 4:
-                    Console.WriteLine(4);
-                    break;
+                        int x = 5;
+
+                        switch (x)
+                        {
+                        case 1:
+                        Console.WriteLine(1);
+                        break;
+                        case 2:
+                        Console.WriteLine(2);  
+                        break;
+                        case 3:
+                        Console.WriteLine(3);
+                        break;
+                        case 4:
+                        Console.WriteLine(4);
+                        break;
+                        }
                     }
                 }
+                ");
+                var root = syntaxTree.GetRoot();
+                var methodDeclaration = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+
+                // Act
+                var complexity = CyclomaticComplexityCalculator.Calculate(methodDeclaration);
+
+                // Assert
+                Assert.Equal(6, complexity);
             }
-            ");
-            var root = syntaxTree.GetRoot();
-            var methodDeclaration = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
 
-            // Act
-            var complexity = CyclomaticComplexityCalculator.Calculate(methodDeclaration);
-
-            // Assert
-            Assert.Equal(6, complexity);
         }
     }
 }

--- a/CodeLineCounter.Tests/CyclomaticComplexityCalculatorTests.cs
+++ b/CodeLineCounter.Tests/CyclomaticComplexityCalculatorTests.cs
@@ -9,6 +9,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void TestCalculateComplexity()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var code = @"
                     public class TestClass
@@ -32,6 +34,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void Calculate_Should_Return_Correct_Complexity()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var syntaxTree = CSharpSyntaxTree.ParseText(@"
                 public class MyClass
@@ -62,6 +66,8 @@ namespace CodeLineCounter.Tests
         [Fact]
          public void Calculate_Should_Return_Correct_Complexity_6()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var syntaxTree = CSharpSyntaxTree.ParseText(@"
             class Program

--- a/CodeLineCounter.Tests/DataExporterTests.cs
+++ b/CodeLineCounter.Tests/DataExporterTests.cs
@@ -1,6 +1,5 @@
 using CodeLineCounter.Models;
 using CodeLineCounter.Utils;
-using Moq;
 
 namespace CodeLineCounter.Tests
 {
@@ -20,6 +19,8 @@ namespace CodeLineCounter.Tests
         [InlineData(CoreUtils.ExportFormat.JSON, ".json")]
         public void Export_SingleItem_CreatesFileWithCorrectExtension(CoreUtils.ExportFormat format, string expectedExtension)
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var testItem = new TestClass { Id = 1, Name = "Test" };
             var filePath = Path.Combine(_testDirectory, "test");
@@ -36,6 +37,8 @@ namespace CodeLineCounter.Tests
         [InlineData(CoreUtils.ExportFormat.JSON, ".json")]
         public void ExportCollection_WithMultipleItems_CreatesFile(CoreUtils.ExportFormat format, string expectedExtension)
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var items = new List<TestClass>
             {
@@ -54,6 +57,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void ExportMetrics_CreatesFileWithCorrectData()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var metrics = new List<NamespaceMetrics>
             {
@@ -69,7 +74,7 @@ namespace CodeLineCounter.Tests
             var filePath = Path.Combine(_testDirectory, "metrics");
 
             // Act
-            DataExporter.ExportMetrics(filePath, metrics, projectTotals, 300, duplications, null, CoreUtils.ExportFormat.CSV);
+            DataExporter.ExportMetrics(filePath, metrics, projectTotals, 300, duplications, ".", CoreUtils.ExportFormat.CSV);
 
             // Assert
             Assert.True(File.Exists(filePath + ".csv"));
@@ -78,6 +83,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void ExportDuplications_CreatesFileWithCorrectData()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var duplications = new List<DuplicationCode>
             {
@@ -96,6 +103,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_duplication_counts_returns_correct_counts_for_duplicate_paths()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var duplications = new List<DuplicationCode>
             {
                 new DuplicationCode { FilePath = "file1.cs" },
@@ -113,6 +122,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_duplication_counts_returns_empty_dictionary_for_empty_list()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var duplications = new List<DuplicationCode>();
 
             var result = DataExporter.GetDuplicationCounts(duplications);
@@ -123,6 +134,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_duplication_counts_handles_absolute_paths()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var absolutePath = Path.GetFullPath(@"C:\test\file.cs");
             var duplications = new List<DuplicationCode>
             {
@@ -138,10 +151,12 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_file_duplications_count_returns_correct_count_when_path_exists()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var duplicationCounts = new Dictionary<string, uint>
-    {
-        { Path.Combine(Path.GetFullPath("."), "test.cs"), 5 }
-    };
+            {
+                { Path.Combine(Path.GetFullPath("."), "test.cs"), 5 }
+            };
 
             var metric = new NamespaceMetrics { FilePath = "test.cs" };
 
@@ -153,6 +168,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_file_duplications_count_returns_zero_when_path_not_found()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var duplicationCounts = new Dictionary<string, uint>();
 
             var metric = new NamespaceMetrics { FilePath = "nonexistent.cs" };
@@ -165,6 +182,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_file_duplications_count_returns_zero_when_filepath_null()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var duplicationCounts = new Dictionary<string, uint>
             {
                 { Path.Combine(Path.GetFullPath("."), "test.cs"), 5 }
@@ -181,6 +200,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_file_duplications_count_uses_current_dir_for_empty_solution_path()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var expectedPath = Path.Combine(Path.GetFullPath("."), "test.cs");
             var duplicationCounts = new Dictionary<string, uint>
             {
@@ -198,6 +219,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_file_duplications_count_uses_current_dir_for_null_solution_path()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var expectedPath = Path.Combine(Path.GetFullPath("."), "test.cs");
             var duplicationCounts = new Dictionary<string, uint>
             {
@@ -215,13 +238,15 @@ namespace CodeLineCounter.Tests
         [Fact]
         public async Task export_dependencies_creates_files_in_correct_formats()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             var dependencies = new List<DependencyRelation>
             {
                 new DependencyRelation { SourceClass = "ClassA", SourceNamespace = "NamespaceA", SourceAssembly = "AssemblyA", TargetClass = "ClassB", TargetNamespace = "NamespaceB", TargetAssembly = "AssemblyB", FilePath = "file1.cs", StartLine = 10 },
             };
 
-            var testFilePath = "test_export";
+            var testFilePath = Path.Combine(Path.GetFullPath("."),"test_export.dot");
             var format = CoreUtils.ExportFormat.JSON;
 
             // Act
@@ -260,6 +285,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void export_collection_throws_when_filepath_null()
         {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             // Arrange
             string? filePath = null;
             var testData = new List<TestClass> { new TestClass { Id = 1, Name = "Test" } };

--- a/CodeLineCounter.Tests/DataExporterTests.cs
+++ b/CodeLineCounter.Tests/DataExporterTests.cs
@@ -93,7 +93,7 @@ namespace CodeLineCounter.Tests
                 DataExporter.ExportMetrics(filePath, _testDirectory, result, ".", CoreUtils.ExportFormat.CSV);
 
                 // Assert
-                Assert.True(File.Exists(filePath + ".csv"));
+                Assert.True(File.Exists(Path.Combine(_testDirectory,filePath + ".csv")));
             }
 
         }
@@ -116,7 +116,7 @@ namespace CodeLineCounter.Tests
                 DataExporter.ExportDuplications(filePath, _testDirectory, duplications, CoreUtils.ExportFormat.CSV);
 
                 // Assert
-                Assert.True(File.Exists(filePath + ".csv"));
+                Assert.True(File.Exists(Path.Combine(_testDirectory,filePath + ".csv")));
             }
 
         }

--- a/CodeLineCounter.Tests/DataExporterTests.cs
+++ b/CodeLineCounter.Tests/DataExporterTests.cs
@@ -19,17 +19,20 @@ namespace CodeLineCounter.Tests
         [InlineData(CoreUtils.ExportFormat.JSON, ".json")]
         public void Export_SingleItem_CreatesFileWithCorrectExtension(CoreUtils.ExportFormat format, string expectedExtension)
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var testItem = new TestClass { Id = 1, Name = "Test" };
-            var filePath = "test";
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                var testItem = new TestClass { Id = 1, Name = "Test" };
+                var filePath = "test";
 
-            // Act
-            DataExporter.Export(filePath, _testDirectory, testItem, format);
+                // Act
+                DataExporter.Export(filePath, _testDirectory, testItem, format);
 
-            // Assert
-            Assert.True(File.Exists(Path.Combine(_testDirectory, filePath + expectedExtension)));
+                // Assert
+                Assert.True(File.Exists(Path.Combine(_testDirectory, filePath + expectedExtension)));
+            }
+
         }
 
         [Theory]
@@ -37,257 +40,293 @@ namespace CodeLineCounter.Tests
         [InlineData(CoreUtils.ExportFormat.JSON, ".json")]
         public void ExportCollection_WithMultipleItems_CreatesFile(CoreUtils.ExportFormat format, string expectedExtension)
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var items = new List<TestClass>
+            using (var sw = new StringWriter())
             {
-                new() { Id = 1, Name = "Test1" },
-                new() { Id = 2, Name = "Test2" }
-            };
-            var filePath = Path.Combine(_testDirectory, "collection");
+                Console.SetOut(sw);
+                // Arrange
+                var items = new List<TestClass>
+                {
+                    new() { Id = 1, Name = "Test1" },
+                    new() { Id = 2, Name = "Test2" }
+                };
+                var filePath = Path.Combine(_testDirectory, "collection");
 
-            // Act
-            DataExporter.ExportCollection(filePath, _testDirectory, items, format);
+                // Act
+                DataExporter.ExportCollection(filePath, _testDirectory, items, format);
 
-            // Assert
-            Assert.True(File.Exists(filePath + expectedExtension));
+                // Assert
+                Assert.True(File.Exists(filePath + expectedExtension));
+            }
+
         }
 
         [Fact]
         public void ExportMetrics_CreatesFileWithCorrectData()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var metrics = new List<NamespaceMetrics>
+            using (var sw = new StringWriter())
             {
-                new() { ProjectName = "Project1", LineCount = 100 },
-                new() { ProjectName = "Project2", LineCount = 200 }
-            };
-            var projectTotals = new Dictionary<string, int>
-            {
-                { "Project1", 100 },
-                { "Project2", 200 }
-            };
-            var duplications = new List<DuplicationCode>();
-            var filePath = "metrics";
-            AnalysisResult result = new AnalysisResult
-            {
-                Metrics = metrics,
-                ProjectTotals = projectTotals,
-                DuplicationMap = duplications,
-                DependencyList = new List<DependencyRelation>(),
-                TotalLines = 300,
-                SolutionFileName = "TestSolution"
-            };
+                Console.SetOut(sw);
+                // Arrange
+                var metrics = new List<NamespaceMetrics>
+                {
+                    new() { ProjectName = "Project1", LineCount = 100 },
+                    new() { ProjectName = "Project2", LineCount = 200 }
+                };
+                var projectTotals = new Dictionary<string, int>
+                {
+                    { "Project1", 100 },
+                    { "Project2", 200 }
+                };
+                var duplications = new List<DuplicationCode>();
+                var filePath = "metrics";
+                AnalysisResult result = new AnalysisResult
+                {
+                    Metrics = metrics,
+                    ProjectTotals = projectTotals,
+                    DuplicationMap = duplications,
+                    DependencyList = new List<DependencyRelation>(),
+                    TotalLines = 300,
+                    SolutionFileName = "TestSolution"
+                };
 
-            // Act
-            DataExporter.ExportMetrics(filePath, _testDirectory, result, ".",CoreUtils.ExportFormat.CSV);
+                // Act
+                DataExporter.ExportMetrics(filePath, _testDirectory, result, ".", CoreUtils.ExportFormat.CSV);
 
-            // Assert
-            Assert.True(File.Exists(filePath + ".csv"));
+                // Assert
+                Assert.True(File.Exists(filePath + ".csv"));
+            }
+
         }
 
         [Fact]
         public void ExportDuplications_CreatesFileWithCorrectData()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var duplications = new List<DuplicationCode>
+            using (var sw = new StringWriter())
             {
-                new() { CodeHash = "hash1", FilePath = "file1.cs", MethodName = "method1", StartLine = 10, NbLines = 20 },
-                new() { CodeHash = "hash2", FilePath = "file2.cs", MethodName = "method2", StartLine = 8, NbLines = 10 }
-            };
-            var filePath = "duplications";
+                Console.SetOut(sw);
+                // Arrange
+                var duplications = new List<DuplicationCode>
+                {
+                    new() { CodeHash = "hash1", FilePath = "file1.cs", MethodName = "method1", StartLine = 10, NbLines = 20 },
+                    new() { CodeHash = "hash2", FilePath = "file2.cs", MethodName = "method2", StartLine = 8, NbLines = 10 }
+                };
+                var filePath = "duplications";
 
-            // Act
-            DataExporter.ExportDuplications(filePath, _testDirectory, duplications, CoreUtils.ExportFormat.CSV);
+                // Act
+                DataExporter.ExportDuplications(filePath, _testDirectory, duplications, CoreUtils.ExportFormat.CSV);
 
-            // Assert
-            Assert.True(File.Exists(filePath + ".csv"));
+                // Assert
+                Assert.True(File.Exists(filePath + ".csv"));
+            }
+
         }
 
         [Fact]
         public void get_duplication_counts_returns_correct_counts_for_duplicate_paths()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var duplications = new List<DuplicationCode>
+            using (var sw = new StringWriter())
             {
-                new DuplicationCode { FilePath = "file1.cs" },
-                new DuplicationCode { FilePath = "file1.cs" },
-                new DuplicationCode { FilePath = "file2.cs" },
-                new DuplicationCode { FilePath = "file1.cs" }
-            };
+                Console.SetOut(sw);
+                var duplications = new List<DuplicationCode>
+                {
+                    new DuplicationCode { FilePath = "file1.cs" },
+                    new DuplicationCode { FilePath = "file1.cs" },
+                    new DuplicationCode { FilePath = "file2.cs" },
+                    new DuplicationCode { FilePath = "file1.cs" }
+                };
 
-            var result = DataExporter.GetDuplicationCounts(duplications);
+                var result = DataExporter.GetDuplicationCounts(duplications);
 
-            Assert.Equal(3u, result[Path.GetFullPath("file1.cs")]);
-            Assert.Equal(1u, result[Path.GetFullPath("file2.cs")]);
+                Assert.Equal(3u, result[Path.GetFullPath("file1.cs")]);
+                Assert.Equal(1u, result[Path.GetFullPath("file2.cs")]);
+            }
+
         }
 
         [Fact]
         public void get_duplication_counts_returns_empty_dictionary_for_empty_list()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var duplications = new List<DuplicationCode>();
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var duplications = new List<DuplicationCode>();
 
-            var result = DataExporter.GetDuplicationCounts(duplications);
+                var result = DataExporter.GetDuplicationCounts(duplications);
 
-            Assert.Empty(result);
+                Assert.Empty(result);
+            }
+
         }
 
         [Fact]
         public void get_duplication_counts_handles_absolute_paths()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var absolutePath = Path.GetFullPath(@"C:\test\file.cs");
-            var duplications = new List<DuplicationCode>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var absolutePath = Path.GetFullPath(@"C:\test\file.cs");
+                var duplications = new List<DuplicationCode>
             {
                 new DuplicationCode { FilePath = absolutePath },
                 new DuplicationCode { FilePath = absolutePath }
             };
 
-            var result = DataExporter.GetDuplicationCounts(duplications);
+                var result = DataExporter.GetDuplicationCounts(duplications);
 
-            Assert.Equal(2u, result[absolutePath]);
+                Assert.Equal(2u, result[absolutePath]);
+            }
+
         }
 
         [Fact]
         public void get_file_duplications_count_returns_correct_count_when_path_exists()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var duplicationCounts = new Dictionary<string, uint>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var duplicationCounts = new Dictionary<string, uint>
             {
                 { Path.Combine(Path.GetFullPath("."), "test.cs"), 5 }
             };
 
-            var metric = new NamespaceMetrics { FilePath = "test.cs" };
+                var metric = new NamespaceMetrics { FilePath = "test.cs" };
 
-            var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
+                var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
 
-            Assert.Equal(5, result);
+                Assert.Equal(5, result);
+            }
+
         }
 
         [Fact]
         public void get_file_duplications_count_returns_zero_when_path_not_found()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var duplicationCounts = new Dictionary<string, uint>();
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var duplicationCounts = new Dictionary<string, uint>();
 
-            var metric = new NamespaceMetrics { FilePath = "nonexistent.cs" };
+                var metric = new NamespaceMetrics { FilePath = "nonexistent.cs" };
 
-            var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
+                var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
 
-            Assert.Equal(0, result);
+                Assert.Equal(0, result);
+            }
+
         }
 
         [Fact]
         public void get_file_duplications_count_returns_zero_when_filepath_null()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var duplicationCounts = new Dictionary<string, uint>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var duplicationCounts = new Dictionary<string, uint>
             {
                 { Path.Combine(Path.GetFullPath("."), "test.cs"), 5 }
             };
 
-            var metric = new NamespaceMetrics { FilePath = null };
+                var metric = new NamespaceMetrics { FilePath = null };
 
-            var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
+                var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
 
-            Assert.Equal(0, result);
+                Assert.Equal(0, result);
+            }
+
         }
 
         // Handles empty string solutionPath by using current directory
         [Fact]
         public void get_file_duplications_count_uses_current_dir_for_empty_solution_path()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var expectedPath = Path.Combine(Path.GetFullPath("."), "test.cs");
-            var duplicationCounts = new Dictionary<string, uint>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var expectedPath = Path.Combine(Path.GetFullPath("."), "test.cs");
+                var duplicationCounts = new Dictionary<string, uint>
             {
                 { expectedPath, 3 }
             };
 
-            var metric = new NamespaceMetrics { FilePath = "test.cs" };
+                var metric = new NamespaceMetrics { FilePath = "test.cs" };
 
-            var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, string.Empty);
+                var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, string.Empty);
 
-            Assert.Equal(3, result);
+                Assert.Equal(3, result);
+            }
+
         }
 
         // Handles null solutionPath by using current directory
         [Fact]
         public void get_file_duplications_count_uses_current_dir_for_null_solution_path()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var expectedPath = Path.Combine(Path.GetFullPath("."), "test.cs");
-            var duplicationCounts = new Dictionary<string, uint>
+            using (var sw = new StringWriter())
             {
-                { expectedPath, 4 }
-            };
+                Console.SetOut(sw);
+                var expectedPath = Path.Combine(Path.GetFullPath("."), "test.cs");
+                var duplicationCounts = new Dictionary<string, uint>
+                {
+                    { expectedPath, 4 }
+                };
 
-            var metric = new NamespaceMetrics { FilePath = "test.cs" };
+                var metric = new NamespaceMetrics { FilePath = "test.cs" };
 
-            var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
+                var result = DataExporter.GetFileDuplicationsCount(duplicationCounts, metric, null);
 
-            Assert.Equal(4, result);
+                Assert.Equal(4, result);
+            }
+
         }
 
         // Successfully exports dependencies to specified format (CSV/JSON) and creates DOT file
         [Fact]
         public async Task export_dependencies_creates_files_in_correct_formats()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var dependencies = new List<DependencyRelation>
+            using (var sw = new StringWriter())
             {
-                new DependencyRelation { SourceClass = "ClassA", SourceNamespace = "NamespaceA", SourceAssembly = "AssemblyA", TargetClass = "ClassB", TargetNamespace = "NamespaceB", TargetAssembly = "AssemblyB", FilePath = "file1.cs", StartLine = 10 },
-            };
-
-            var testFilePath = "test_export.dot";
-            var format = CoreUtils.ExportFormat.JSON;
-
-            // Act
-            await DataExporter.ExportDependencies(testFilePath, _testDirectory, dependencies, format);
-
-            // Assert
-            string expectedJsonPath = Path.Combine(_testDirectory, CoreUtils.GetExportFileNameWithExtension(testFilePath, format));
-            string expectedDotPath = Path.ChangeExtension(expectedJsonPath, ".dot");
-
-            Assert.True(File.Exists(expectedJsonPath));
-            Assert.True(File.Exists(expectedDotPath));
-
-            try
-            {
-                if (File.Exists(expectedJsonPath))
+                Console.SetOut(sw);
+                // Arrange
+                var dependencies = new List<DependencyRelation>
                 {
-                    File.Delete(expectedJsonPath);
-                }
+                    new DependencyRelation { SourceClass = "ClassA", SourceNamespace = "NamespaceA", SourceAssembly = "AssemblyA", TargetClass = "ClassB", TargetNamespace = "NamespaceB", TargetAssembly = "AssemblyB", FilePath = "file1.cs", StartLine = 10 },
+                };
 
-                if (File.Exists(expectedDotPath))
+                var testFilePath = "test_export.dot";
+                var format = CoreUtils.ExportFormat.JSON;
+
+                // Act
+                await DataExporter.ExportDependencies(testFilePath, _testDirectory, dependencies, format);
+
+                // Assert
+                string expectedJsonPath = Path.Combine(_testDirectory, CoreUtils.GetExportFileNameWithExtension(testFilePath, format));
+                string expectedDotPath = Path.ChangeExtension(expectedJsonPath, ".dot");
+
+                Assert.True(File.Exists(expectedJsonPath));
+                Assert.True(File.Exists(expectedDotPath));
+
+                try
                 {
-                    File.Delete(expectedDotPath);
+                    if (File.Exists(expectedJsonPath))
+                    {
+                        File.Delete(expectedJsonPath);
+                    }
+
+                    if (File.Exists(expectedDotPath))
+                    {
+                        File.Delete(expectedDotPath);
+                    }
+                }
+                catch (IOException ex)
+                {
+                    throw new IOException($"Error deleting files: {ex.Message}", ex);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    throw new UnauthorizedAccessException($"Access denied while deleting files: {ex.Message}", ex);
                 }
             }
-            catch (IOException ex)
-            {
-                throw new IOException($"Error deleting files: {ex.Message}", ex);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                throw new UnauthorizedAccessException($"Access denied while deleting files: {ex.Message}", ex);
-            }
+
         }
 
         // Throws ArgumentException when file path is null

--- a/CodeLineCounter.Tests/DependencyGraphGeneratorTests.cs
+++ b/CodeLineCounter.Tests/DependencyGraphGeneratorTests.cs
@@ -29,13 +29,15 @@ namespace CodeLineCounter.Tests
                 new DependencyRelation { SourceClass = "ClassB", SourceNamespace = "NamespaceB", SourceAssembly = "AssemblyB", TargetClass = "ClassC", TargetNamespace = "NamespaceB", TargetAssembly = "AssemblyB",  FilePath = "path/to/file", StartLine = 1}
             };
 
-            string outputPath = Path.Combine(_testDirectory, "test_graph.dot");
+            string fileName = "test_graph.dot";
+
+            string outputPath = Path.Combine(_testDirectory, fileName);
 
             // Act
 
             DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
             Directory.CreateDirectory(_testDirectory);
-            await DependencyGraphGenerator.CompileGraphAndWriteToFile(outputPath, graph);
+            await DependencyGraphGenerator.CompileGraphAndWriteToFile(fileName,_testDirectory, graph);
 
             // Assert
             Assert.True(File.Exists(outputPath));
@@ -56,11 +58,12 @@ namespace CodeLineCounter.Tests
 
             // Arrange
             var dependencies = new List<DependencyRelation>();
-            string outputPath = Path.Combine(_testDirectory, "empty_graph.dot");
+            string filename = "empty_graph.dot";
+            string outputPath = Path.Combine(_testDirectory, filename);
 
             // Act
             DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
-            await DependencyGraphGenerator.CompileGraphAndWriteToFile(outputPath, graph);
+            await DependencyGraphGenerator.CompileGraphAndWriteToFile(filename, _testDirectory, graph);
 
             // Assert
             Assert.True(File.Exists(outputPath));

--- a/CodeLineCounter.Tests/DependencyGraphGeneratorTests.cs
+++ b/CodeLineCounter.Tests/DependencyGraphGeneratorTests.cs
@@ -19,135 +19,156 @@ namespace CodeLineCounter.Tests
         [Fact]
         public async Task generate_graph_with_valid_dependencies_creates_dot_file()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
 
-            // Arrange
-            var dependencies = new List<DependencyRelation>
+                // Arrange
+                var dependencies = new List<DependencyRelation>
             {
                 new DependencyRelation { SourceClass = "ClassA", SourceNamespace = "NamespaceA", SourceAssembly = "AssemblyA", TargetClass = "ClassB" , TargetNamespace = "NamespaceB", TargetAssembly = "AssemblyB", FilePath = "path/to/file", StartLine = 1},
                 new DependencyRelation { SourceClass = "ClassB", SourceNamespace = "NamespaceB", SourceAssembly = "AssemblyB", TargetClass = "ClassC", TargetNamespace = "NamespaceB", TargetAssembly = "AssemblyB",  FilePath = "path/to/file", StartLine = 1}
             };
 
-            string fileName = "test_graph.dot";
+                string fileName = "test_graph.dot";
 
-            string outputPath = Path.Combine(_testDirectory, fileName);
+                string outputPath = Path.Combine(_testDirectory, fileName);
 
-            // Act
+                // Act
 
-            DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
-            Directory.CreateDirectory(_testDirectory);
-            await DependencyGraphGenerator.CompileGraphAndWriteToFile(fileName,_testDirectory, graph);
+                DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
+                Directory.CreateDirectory(_testDirectory);
+                await DependencyGraphGenerator.CompileGraphAndWriteToFile(fileName, _testDirectory, graph);
 
-            // Assert
-            Assert.True(File.Exists(outputPath));
-            string content = await File.ReadAllTextAsync(outputPath);
-            Assert.Contains("ClassA", content);
-            Assert.Contains("ClassB", content);
-            Assert.Contains("ClassC", content);
+                // Assert
+                Assert.True(File.Exists(outputPath));
+                string content = await File.ReadAllTextAsync(outputPath);
+                Assert.Contains("ClassA", content);
+                Assert.Contains("ClassB", content);
+                Assert.Contains("ClassC", content);
 
-            File.Delete(outputPath);
+                File.Delete(outputPath);
+            }
+
         }
 
         // Empty dependencies list
         [Fact]
         public async Task generate_graph_with_empty_dependencies_creates_empty_graph()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
 
-            // Arrange
-            var dependencies = new List<DependencyRelation>();
-            string filename = "empty_graph.dot";
-            string outputPath = Path.Combine(_testDirectory, filename);
+                // Arrange
+                var dependencies = new List<DependencyRelation>();
+                string filename = "empty_graph.dot";
+                string outputPath = Path.Combine(_testDirectory, filename);
 
-            // Act
-            DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
-            await DependencyGraphGenerator.CompileGraphAndWriteToFile(filename, _testDirectory, graph);
+                // Act
+                DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
+                await DependencyGraphGenerator.CompileGraphAndWriteToFile(filename, _testDirectory, graph);
 
-            // Assert
-            Assert.True(File.Exists(outputPath));
-            string content = await File.ReadAllTextAsync(outputPath);
-            Assert.Contains("digraph", content);
-            Assert.DoesNotContain("->", content);
+                // Assert
+                Assert.True(File.Exists(outputPath));
+                string content = await File.ReadAllTextAsync(outputPath);
+                Assert.Contains("digraph", content);
+                Assert.DoesNotContain("->", content);
 
-            File.Delete(outputPath);
+                File.Delete(outputPath);
+            }
+
         }
 
         [Fact]
         public void create_node_sets_correct_fillcolor_and_style_incoming_greater()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var vertexInfo = new Dictionary<string, (int incoming, int outgoing)>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var vertexInfo = new Dictionary<string, (int incoming, int outgoing)>
             {
                 { "TestVertex", (3, 2) }
             };
 
-            DotNode node = DependencyGraphGenerator.CreateNode(vertexInfo, "TestVertex");
+                DotNode node = DependencyGraphGenerator.CreateNode(vertexInfo, "TestVertex");
 
-            Assert.Equal(DotColor.MediumSeaGreen.ToHexString(), node.FillColor.Value);
-            Assert.Equal(DotNodeStyle.Filled.FlagsToString(), node.Style.Value);
+                Assert.Equal(DotColor.MediumSeaGreen.ToHexString(), node.FillColor.Value);
+                Assert.Equal(DotNodeStyle.Filled.FlagsToString(), node.Style.Value);
+            }
+
         }
 
         [Fact]
         public void create_node_sets_correct_fillcolor_and_style_incoming_lower()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var vertexInfo = new Dictionary<string, (int incoming, int outgoing)>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var vertexInfo = new Dictionary<string, (int incoming, int outgoing)>
             {
                 { "TestVertex", (3, 4) }
             };
 
-            DotNode node = DependencyGraphGenerator.CreateNode(vertexInfo, "TestVertex");
+                DotNode node = DependencyGraphGenerator.CreateNode(vertexInfo, "TestVertex");
 
-            Assert.Equal(DotColor.Salmon.ToHexString(), node.FillColor.Value);
-            Assert.Equal(DotNodeStyle.Filled.FlagsToString(), node.Style.Value);
+                Assert.Equal(DotColor.Salmon.ToHexString(), node.FillColor.Value);
+                Assert.Equal(DotNodeStyle.Filled.FlagsToString(), node.Style.Value);
+            }
+
         }
 
         // Returns empty quoted string '""' for non-empty input string
         [Fact]
         public void enclose_string_in_quotes_returns_empty_quoted_string_for_nonempty_input()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            var input = "test string";
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                var input = "test string";
 
-            // Act 
-            var result = DependencyGraphGenerator.EncloseNotEmptyOrNullStringInQuotes(input);
+                // Act 
+                var result = DependencyGraphGenerator.EncloseNotEmptyOrNullStringInQuotes(input);
 
-            // Assert
-            Assert.Equal("\"test string\"", result);
+                // Assert
+                Assert.Equal("\"test string\"", result);
+            }
+
         }
 
         // Returns quoted string with null value for null input
         [Fact]
         public void enclose_string_in_quotes_returns_quoted_null_for_null_input()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            // Arrange
-            string? input = null;
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                // Arrange
+                string? input = null;
 
-            // Act
-            var result = DependencyGraphGenerator.EncloseNotEmptyOrNullStringInQuotes(input);
+                // Act
+                var result = DependencyGraphGenerator.EncloseNotEmptyOrNullStringInQuotes(input);
 
-            // Assert
-            Assert.Equal(string.Empty, result);
+                // Assert
+                Assert.Equal(string.Empty, result);
+            }
+
         }
 
         // Graph initialization with empty values
         [Fact]
         public void initialize_graph_sets_default_label_and_identifier()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            var graph = DependencyGraphGenerator.InitializeGraph();
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var graph = DependencyGraphGenerator.InitializeGraph();
 
-            Assert.Equal("DependencyGraph", graph.Label.Value);
-            Assert.Equal("DependencyGraph", graph.Identifier.Value);
+                Assert.Equal("DependencyGraph", graph.Label.Value);
+                Assert.Equal("DependencyGraph", graph.Identifier.Value);
+            }
+
         }
 
         protected virtual void Dispose(bool disposing)

--- a/CodeLineCounter.Tests/FileUtilsTests.cs
+++ b/CodeLineCounter.Tests/FileUtilsTests.cs
@@ -2,8 +2,16 @@ using CodeLineCounter.Utils;
 
 namespace CodeLineCounter.Tests
 {
-    public class FileUtilsTests
+    public class FileUtilsTests : IDisposable
     {
+        private readonly string _testDirectory;
+        private bool _disposed;
+
+        public FileUtilsTests()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "DependencyGraphGeneratorTests");
+            Directory.CreateDirectory(_testDirectory);
+        }
         [Fact]
         public void GetSolutionFiles_Should_Return_List_Of_Solution_Files()
         {
@@ -36,7 +44,7 @@ namespace CodeLineCounter.Tests
         public void get_solution_files_throws_exception_for_nonexistent_directory()
         {
             // Arrange
-            var nonExistentPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var nonExistentPath = Path.Combine(_testDirectory, Guid.NewGuid().ToString());
 
             // Act & Assert
             Assert.Throws<UnauthorizedAccessException>(() => FileUtils.GetSolutionFiles(nonExistentPath));
@@ -47,13 +55,40 @@ namespace CodeLineCounter.Tests
         public void get_project_files_throws_when_file_not_exists()
         {
             // Arrange
-            var nonExistentPath = "nonexistent.sln";
+            var nonExistentPath = Path.Combine(_testDirectory, "nonexistent.sln");
 
             // Act & Assert
             var exception = Assert.Throws<UnauthorizedAccessException>(() =>
                 FileUtils.GetProjectFiles(nonExistentPath));
 
             Assert.Contains(nonExistentPath, exception.Message);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing && Directory.Exists(_testDirectory))
+                {
+                    // Dispose managed resources
+                    Directory.Delete(_testDirectory, true);
+                }
+
+                // Dispose unmanaged resources (if any)
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~FileUtilsTests()
+        {
+            Dispose(false);
         }
     }
 }

--- a/CodeLineCounter.Tests/FileUtilsTests.cs
+++ b/CodeLineCounter.Tests/FileUtilsTests.cs
@@ -15,6 +15,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void GetSolutionFiles_Should_Return_List_Of_Solution_Files()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
             // Arrange
             var basePath = FileUtils.GetBasePath();
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
@@ -32,6 +34,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void GetBasePath_Should_Return_NonEmptyString()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
             // Act
             string basePath = FileUtils.GetBasePath();
 
@@ -43,6 +47,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_solution_files_throws_exception_for_nonexistent_directory()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
             // Arrange
             var nonExistentPath = Path.Combine(_testDirectory, Guid.NewGuid().ToString());
 
@@ -54,6 +60,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void get_project_files_throws_when_file_not_exists()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
             // Arrange
             var nonExistentPath = Path.Combine(_testDirectory, "nonexistent.sln");
 

--- a/CodeLineCounter.Tests/FileUtilsTests.cs
+++ b/CodeLineCounter.Tests/FileUtilsTests.cs
@@ -15,61 +15,73 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void GetSolutionFiles_Should_Return_List_Of_Solution_Files()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-            // Arrange
-            var basePath = FileUtils.GetBasePath();
-            var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
-            var rootPath = solutionPath;
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
+                // Arrange
+                var basePath = FileUtils.GetBasePath();
+                var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
+                var rootPath = solutionPath;
 
-            // Act
-            var result = FileUtils.GetSolutionFiles(rootPath);
+                // Act
+                var result = FileUtils.GetSolutionFiles(rootPath);
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.NotEmpty(result);
-            Assert.All(result, file => Assert.EndsWith(".sln", file));
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotEmpty(result);
+                Assert.All(result, file => Assert.EndsWith(".sln", file));
+            }
+
         }
 
         [Fact]
         public void GetBasePath_Should_Return_NonEmptyString()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-            // Act
-            string basePath = FileUtils.GetBasePath();
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
+                // Act
+                string basePath = FileUtils.GetBasePath();
 
-            // Assert
-            Assert.False(string.IsNullOrEmpty(basePath), "Base path should not be null or empty.");
-            Assert.True(Directory.Exists(basePath), "Base path should be a valid directory.");
+                // Assert
+                Assert.False(string.IsNullOrEmpty(basePath), "Base path should not be null or empty.");
+                Assert.True(Directory.Exists(basePath), "Base path should be a valid directory.");
+            }
+
         }
 
         [Fact]
         public void get_solution_files_throws_exception_for_nonexistent_directory()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-            // Arrange
-            var nonExistentPath = Path.Combine(_testDirectory, Guid.NewGuid().ToString());
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
+                // Arrange
+                var nonExistentPath = Path.Combine(_testDirectory, Guid.NewGuid().ToString());
 
-            // Act & Assert
-            Assert.Throws<UnauthorizedAccessException>(() => FileUtils.GetSolutionFiles(nonExistentPath));
+                // Act & Assert
+                Assert.Throws<UnauthorizedAccessException>(() => FileUtils.GetSolutionFiles(nonExistentPath));
+            }
+
         }
 
         // Throws UnauthorizedAccessException when solution file does not exist
         [Fact]
         public void get_project_files_throws_when_file_not_exists()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-            // Arrange
-            var nonExistentPath = Path.Combine(_testDirectory, "nonexistent.sln");
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
+                // Arrange
+                var nonExistentPath = Path.Combine(_testDirectory, "nonexistent.sln");
 
-            // Act & Assert
-            var exception = Assert.Throws<UnauthorizedAccessException>(() =>
-                FileUtils.GetProjectFiles(nonExistentPath));
+                // Act & Assert
+                var exception = Assert.Throws<UnauthorizedAccessException>(() =>
+                    FileUtils.GetProjectFiles(nonExistentPath));
 
-            Assert.Contains(nonExistentPath, exception.Message);
+                Assert.Contains(nonExistentPath, exception.Message);
+            }
+
         }
 
         protected virtual void Dispose(bool disposing)

--- a/CodeLineCounter.Tests/HashUtilsTests.cs
+++ b/CodeLineCounter.Tests/HashUtilsTests.cs
@@ -7,6 +7,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void ComputeHash_EmptyString_ReturnsEmptyString()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             string input = "";
 
@@ -20,6 +23,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void ComputeHash_NullString_ReturnsEmptyString()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             string? input = null;
 
@@ -33,6 +39,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void ComputeHash_ValidString_ReturnsHash()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
             string input = "Hello, World!";
 
@@ -47,6 +56,9 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void ComputeHash_DuplicateStrings_ReturnSameHash()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+            
             // Arrange
             string input1 = "Hello, World!";
             string input2 = "Hello, World!";

--- a/CodeLineCounter.Tests/HashUtilsTests.cs
+++ b/CodeLineCounter.Tests/HashUtilsTests.cs
@@ -7,68 +7,80 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void ComputeHash_EmptyString_ReturnsEmptyString()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Arrange
-            string input = "";
+                // Arrange
+                string input = "";
 
-            // Act
-            string result = HashUtils.ComputeHash(input);
+                // Act
+                string result = HashUtils.ComputeHash(input);
 
-            // Assert
-            Assert.Equal("", result);
+                // Assert
+                Assert.Equal("", result);
+            }
+
         }
 
         [Fact]
         public void ComputeHash_NullString_ReturnsEmptyString()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Arrange
-            string? input = null;
+                // Arrange
+                string? input = null;
 
-            // Act
-            string result = HashUtils.ComputeHash(input);
+                // Act
+                string result = HashUtils.ComputeHash(input);
 
-            // Assert
-            Assert.Equal("", result);
+                // Assert
+                Assert.Equal("", result);
+            }
+
         }
 
         [Fact]
         public void ComputeHash_ValidString_ReturnsHash()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Arrange
-            string input = "Hello, World!";
+                // Arrange
+                string input = "Hello, World!";
 
-            // Act
-            string result = HashUtils.ComputeHash(input);
+                // Act
+                string result = HashUtils.ComputeHash(input);
 
-            // Assert
-            Assert.NotEmpty(result);
-            Assert.IsType<string>(result);
+                // Assert
+                Assert.NotEmpty(result);
+                Assert.IsType<string>(result);
+            }
+
         }
 
         [Fact]
         public void ComputeHash_DuplicateStrings_ReturnSameHash()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
-            
-            // Arrange
-            string input1 = "Hello, World!";
-            string input2 = "Hello, World!";
+            using (StringWriter consoleOutput = new())
+            {
+                Console.SetOut(consoleOutput);
 
-            // Act
-            string result1 = HashUtils.ComputeHash(input1);
-            string result2 = HashUtils.ComputeHash(input2);
+                // Arrange
+                string input1 = "Hello, World!";
+                string input2 = "Hello, World!";
 
-            // Assert
-            Assert.Equal(result1, result2);
+                // Act
+                string result1 = HashUtils.ComputeHash(input1);
+                string result2 = HashUtils.ComputeHash(input2);
+
+                // Assert
+                Assert.Equal(result1, result2);
+            }
+
         }
     }
 }

--- a/CodeLineCounter.Tests/JsonHandlerTests.cs
+++ b/CodeLineCounter.Tests/JsonHandlerTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 namespace CodeLineCounter.Tests
 {
-    public class JsonHandlerTests :IDisposable
+    public class JsonHandlerTests : IDisposable
     {
 
         private readonly string _testDirectory;
@@ -30,29 +30,30 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void deserialize_valid_json_file_returns_expected_objects()
         {
-            using (StringWriter consoleOutput = new()){
+            using (StringWriter consoleOutput = new())
+            {
                 Console.SetOut(consoleOutput);
 
-            // Arrange
-            var testFilePath = Path.Combine(_testDirectory, "test.json");
-            var expectedData = new[] { new TestClass(id: 1, name: "Test") };
-            File.WriteAllText(testFilePath, JsonSerializer.Serialize(expectedData));
+                // Arrange
+                var testFilePath = Path.Combine(_testDirectory, "test.json");
+                var expectedData = new[] { new TestClass(id: 1, name: "Test") };
+                File.WriteAllText(testFilePath, JsonSerializer.Serialize(expectedData));
 
-            // Act
-            var result = JsonHandler.Deserialize<TestClass>(testFilePath);
+                // Act
+                var result = JsonHandler.Deserialize<TestClass>(testFilePath);
 
-            // Assert
-            Assert.Equal(expectedData.Length, result.Count());
-            Assert.Equal(expectedData[0].Id, result.First().Id);
-            Assert.Equal(expectedData[0].Name, result.First().Name);
+                // Assert
+                Assert.Equal(expectedData.Length, result.Count());
+                Assert.Equal(expectedData[0].Id, result.First().Id);
+                Assert.Equal(expectedData[0].Name, result.First().Name);
 
-            File.Delete(testFilePath);
+                File.Delete(testFilePath);
 
             }
-            
+
         }
 
-         protected virtual void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
             {

--- a/CodeLineCounter.Tests/JsonHandlerTests.cs
+++ b/CodeLineCounter.Tests/JsonHandlerTests.cs
@@ -3,8 +3,18 @@ using System.Text.Json;
 
 namespace CodeLineCounter.Tests
 {
-    public class JsonHandlerTests
+    public class JsonHandlerTests :IDisposable
     {
+
+        private readonly string _testDirectory;
+        private bool _disposed;
+
+        public JsonHandlerTests()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "JsonHandlerTests");
+            Directory.CreateDirectory(_testDirectory);
+        }
+
         public class TestClass
         {
             public int Id { get; set; }
@@ -20,8 +30,11 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void deserialize_valid_json_file_returns_expected_objects()
         {
+            using StringWriter consoleOutput = new();
+            Console.SetOut(consoleOutput);
+
             // Arrange
-            var testFilePath = "test.json";
+            var testFilePath = Path.Combine(_testDirectory, "test.json");
             var expectedData = new[] { new TestClass(id: 1, name: "Test") };
             File.WriteAllText(testFilePath, JsonSerializer.Serialize(expectedData));
 
@@ -34,6 +47,33 @@ namespace CodeLineCounter.Tests
             Assert.Equal(expectedData[0].Name, result.First().Name);
 
             File.Delete(testFilePath);
+        }
+
+         protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing && Directory.Exists(_testDirectory))
+                {
+                    // Dispose managed resources
+                    Directory.Delete(_testDirectory, true);
+                }
+
+                // Dispose unmanaged resources (if any)
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~JsonHandlerTests()
+        {
+            Dispose(false);
         }
 
     }

--- a/CodeLineCounter.Tests/JsonHandlerTests.cs
+++ b/CodeLineCounter.Tests/JsonHandlerTests.cs
@@ -30,8 +30,8 @@ namespace CodeLineCounter.Tests
         [Fact]
         public void deserialize_valid_json_file_returns_expected_objects()
         {
-            using StringWriter consoleOutput = new();
-            Console.SetOut(consoleOutput);
+            using (StringWriter consoleOutput = new()){
+                Console.SetOut(consoleOutput);
 
             // Arrange
             var testFilePath = Path.Combine(_testDirectory, "test.json");
@@ -47,6 +47,9 @@ namespace CodeLineCounter.Tests
             Assert.Equal(expectedData[0].Name, result.First().Name);
 
             File.Delete(testFilePath);
+
+            }
+            
         }
 
          protected virtual void Dispose(bool disposing)

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -20,11 +20,12 @@ namespace CodeLineCounter.Tests.Services
         public void analyze_and_export_solution_succeeds_with_valid_inputs()
         {
             // Arrange
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var basePath = FileUtils.GetBasePath();
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
             solutionPath = Path.Combine(solutionPath, "CodeLineCounter.sln");
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
+            
             var verbose = false;
             var format = CoreUtils.ExportFormat.JSON;
 
@@ -39,6 +40,8 @@ namespace CodeLineCounter.Tests.Services
         public void analyze_and_export_solution_throws_on_invalid_path()
         {
             // Arrange
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
             var invalidPath = "";
             var verbose = false;
             var format = CoreUtils.ExportFormat.JSON;

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -177,26 +177,25 @@ namespace CodeLineCounter.Tests.Services
         [Fact]
         public void export_results_with_valid_input_exports_all_files()
         {
-            // Arrange
-            var result = new AnalysisResult
-            {
-                SolutionFileName = "TestSolution",
-                Metrics = new List<NamespaceMetrics>(),
-                ProjectTotals = new Dictionary<string, int>(),
-                TotalLines = 1000,
-                DuplicationMap = new List<DuplicationCode>(),
-                DependencyList = new List<DependencyRelation>()
-            };
-
-            var basePath = _testDirectory;
-            var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
-
-            solutionPath = Path.Combine(solutionPath, "TestSolution.sln");
-            var format = CoreUtils.ExportFormat.CSV;
-
-            // Act
+          // Act
             using (var sw = new StringWriter())
             {
+                // Arrange
+                var result = new AnalysisResult
+                {
+                    SolutionFileName = "TestSolution",
+                    Metrics = new List<NamespaceMetrics>(),
+                    ProjectTotals = new Dictionary<string, int>(),
+                    TotalLines = 1000,
+                    DuplicationMap = new List<DuplicationCode>(),
+                    DependencyList = new List<DependencyRelation>()
+                };
+
+                var basePath = _testDirectory;
+                var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
+
+                solutionPath = Path.Combine(solutionPath, "TestSolution.sln");
+                var format = CoreUtils.ExportFormat.CSV;
                 Console.SetOut(sw);
                 SolutionAnalyzer.ExportResults(result, solutionPath, format);
                 // Assert

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -4,8 +4,17 @@ using CodeLineCounter.Utils;
 
 namespace CodeLineCounter.Tests.Services
 {
-    public class SolutionAnalyzerTest
+    public class SolutionAnalyzerTest : IDisposable
     {
+
+        private readonly string _testDirectory;
+        private bool _disposed;
+
+        public SolutionAnalyzerTest()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "SolutionAnalyzerTest");
+            Directory.CreateDirectory(_testDirectory);
+        }
 
         [Fact]
         public void analyze_and_export_solution_succeeds_with_valid_inputs()
@@ -14,7 +23,7 @@ namespace CodeLineCounter.Tests.Services
             var basePath = FileUtils.GetBasePath();
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
             solutionPath = Path.Combine(solutionPath, "CodeLineCounter.sln");
-            var sw = new StringWriter();
+            using var sw = new StringWriter();
             Console.SetOut(sw);
             var verbose = false;
             var format = CoreUtils.ExportFormat.JSON;
@@ -48,7 +57,7 @@ namespace CodeLineCounter.Tests.Services
             var basePath = FileUtils.GetBasePath();
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
             solutionPath = Path.Combine(solutionPath, "CodeLineCounter.sln");
-            var sw = new StringWriter();
+            using var sw = new StringWriter();
             Console.SetOut(sw);
             Console.WriteLine($"Constructed solution path: {solutionPath}");
             Assert.True(File.Exists(solutionPath), $"The solution file '{solutionPath}' does not exist.");
@@ -165,7 +174,7 @@ namespace CodeLineCounter.Tests.Services
                 DependencyList = new List<DependencyRelation>()
             };
 
-            var basePath = FileUtils.GetBasePath();
+            var basePath = _testDirectory;
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
 
             solutionPath = Path.Combine(solutionPath, "TestSolution.sln");
@@ -182,6 +191,33 @@ namespace CodeLineCounter.Tests.Services
             Assert.True(File.Exists("TestSolution-CodeMetrics.csv"));
             Assert.True(File.Exists("TestSolution-CodeDuplications.csv"));
             Assert.True(File.Exists("TestSolution-CodeDependencies.csv"));
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing && Directory.Exists(_testDirectory))
+                {
+                    // Dispose managed resources
+                    Directory.Delete(_testDirectory, true);
+                }
+
+                // Dispose unmanaged resources (if any)
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~SolutionAnalyzerTest()
+        {
+            Dispose(false);
         }
 
     }

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -20,37 +20,44 @@ namespace CodeLineCounter.Tests.Services
         public void analyze_and_export_solution_succeeds_with_valid_inputs()
         {
             // Arrange
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
             var basePath = FileUtils.GetBasePath();
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
             solutionPath = Path.Combine(solutionPath, "CodeLineCounter.sln");
-            
+
             var verbose = false;
             var format = CoreUtils.ExportFormat.JSON;
 
             // Act & Assert
-            var exception = Record.Exception(() =>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var exception = Record.Exception(() =>
                 SolutionAnalyzer.AnalyzeAndExportSolution(solutionPath, verbose, format));
 
-            Assert.Null(exception);
+                Assert.Null(exception);
+            }
         }
 
         [Fact]
         public void analyze_and_export_solution_throws_on_invalid_path()
         {
             // Arrange
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
+
             var invalidPath = "";
             var verbose = false;
             var format = CoreUtils.ExportFormat.JSON;
 
             // Act & Assert
-            var exception = Assert.Throws<UnauthorizedAccessException>(() =>
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var exception = Assert.Throws<UnauthorizedAccessException>(() =>
                 SolutionAnalyzer.AnalyzeAndExportSolution(invalidPath, verbose, format));
 
-            Assert.Contains("Access to the path '' is denied.", exception.Message);
+                Assert.Contains("Access to the path '' is denied.", exception.Message);
+
+            }
+
         }
 
         [Fact]
@@ -60,19 +67,23 @@ namespace CodeLineCounter.Tests.Services
             var basePath = FileUtils.GetBasePath();
             var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
             solutionPath = Path.Combine(solutionPath, "CodeLineCounter.sln");
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-            Console.WriteLine($"Constructed solution path: {solutionPath}");
-            Assert.True(File.Exists(solutionPath), $"The solution file '{solutionPath}' does not exist.");
-            Console.WriteLine($"Constructed solution path: {solutionPath}");
-            Assert.True(File.Exists(solutionPath), $"The solution file '{solutionPath}' does not exist.");
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                Console.WriteLine($"Constructed solution path: {solutionPath}");
+                Assert.True(File.Exists(solutionPath), $"The solution file '{solutionPath}' does not exist.");
+                Console.WriteLine($"Constructed solution path: {solutionPath}");
+                Assert.True(File.Exists(solutionPath), $"The solution file '{solutionPath}' does not exist.");
 
-            // Act
-            var result = SolutionAnalyzer.PerformAnalysis(solutionPath);
+                // Act
+                var result = SolutionAnalyzer.PerformAnalysis(solutionPath);
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal("CodeLineCounter.sln", result.SolutionFileName);
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("CodeLineCounter.sln", result.SolutionFileName);
+
+            }
+
         }
 
         [Fact]
@@ -188,12 +199,13 @@ namespace CodeLineCounter.Tests.Services
             {
                 Console.SetOut(sw);
                 SolutionAnalyzer.ExportResults(result, solutionPath, format);
+                // Assert
+                Assert.True(File.Exists("TestSolution-CodeMetrics.csv"));
+                Assert.True(File.Exists("TestSolution-CodeDuplications.csv"));
+                Assert.True(File.Exists("TestSolution-CodeDependencies.csv"));
             }
 
-            // Assert
-            Assert.True(File.Exists("TestSolution-CodeMetrics.csv"));
-            Assert.True(File.Exists("TestSolution-CodeDuplications.csv"));
-            Assert.True(File.Exists("TestSolution-CodeDependencies.csv"));
+
         }
 
         protected virtual void Dispose(bool disposing)

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -26,7 +26,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""TestProject"", ""TestProject\TestProject.csproj"", ""{F60AAFF8-A3B6-4D3C-9372-06A0F1B6F82B}""
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""TestProject"", ""TestProject.csproj"", ""{F60AAFF8-A3B6-4D3C-9372-06A0F1B6F82B}""
 EndProject");
             }
         }

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -8,49 +8,82 @@ namespace CodeLineCounter.Tests.Services
     {
 
         private readonly string _testDirectory;
+        private readonly string _testSolutionPath;
+        private readonly string _outputPath;
         private bool _disposed;
 
         public SolutionAnalyzerTest()
         {
             _testDirectory = Path.Combine(Path.GetTempPath(), "SolutionAnalyzerTest");
+            _testSolutionPath = Path.Combine(_testDirectory, "TestSolution.sln");
+            _outputPath = _testDirectory;
             Directory.CreateDirectory(_testDirectory);
+            // Create minimal test solution if it doesn't exist
+            if (!File.Exists(_testSolutionPath))
+            {
+                File.WriteAllText(_testSolutionPath, @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""TestProject"", ""TestProject\TestProject.csproj"", ""{F60AAFF8-A3B6-4D3C-9372-06A0F1B6F82B}""
+EndProject");
+            }
         }
 
         [Fact]
         public void analyze_and_export_solution_succeeds_with_valid_inputs()
         {
             // Arrange
-            var basePath = FileUtils.GetBasePath();
-            var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
-            solutionPath = Path.Combine(solutionPath, "CodeLineCounter.sln");
+            var solutionPath = _testSolutionPath;
+            var verbose = true;
+            var format = CoreUtils.ExportFormat.CSV;
+            var outputPath = _outputPath;
 
-            var verbose = false;
-            var format = CoreUtils.ExportFormat.JSON;
-
-            // Act & Assert
-            using (var sw = new StringWriter())
+            try
             {
-                Console.SetOut(sw);
-                var exception = Record.Exception(() =>
-                SolutionAnalyzer.AnalyzeAndExportSolution(solutionPath, verbose, format));
+                // Redirect console output
+                using (StringWriter stringWriter = new StringWriter())
+                {
 
-                Assert.Null(exception);
+                    Console.SetOut(stringWriter);
+
+                    // Act
+                    var exception = Record.Exception(() =>
+                    {
+                        SolutionAnalyzer.AnalyzeAndExportSolution(_testSolutionPath, verbose, format, outputPath);
+                    });
+
+                    // Assert
+                    Assert.Null(exception);
+                    Assert.True(File.Exists(Path.Combine(outputPath, "TestSolution-CodeMetrics.csv")));
+                }
+
+            }
+            finally
+            {
+                // Cleanup
+
+                if (File.Exists(solutionPath))
+                {
+                    File.Delete(solutionPath);
+                }
             }
         }
 
         [Fact]
         public void analyze_and_export_solution_throws_on_invalid_path()
         {
-            // Arrange
-
-            var invalidPath = "";
-            var verbose = false;
-            var format = CoreUtils.ExportFormat.JSON;
-
-            // Act & Assert
             using (var sw = new StringWriter())
             {
                 Console.SetOut(sw);
+                // Arrange
+
+                var invalidPath = "";
+                var verbose = false;
+                var format = CoreUtils.ExportFormat.JSON;
+
+                // Act & Assert
                 var exception = Assert.Throws<UnauthorizedAccessException>(() =>
                 SolutionAnalyzer.AnalyzeAndExportSolution(invalidPath, verbose, format));
 
@@ -89,24 +122,23 @@ namespace CodeLineCounter.Tests.Services
         [Fact]
         public void OutputAnalysisResults_ShouldPrintCorrectOutput()
         {
-            // Arrange
-            var result = new AnalysisResult
-            {
-                Metrics = new List<NamespaceMetrics>(),
-                ProjectTotals = new Dictionary<string, int>(),
-                TotalLines = 1000,
-                TotalFiles = 10,
-                DuplicationMap = new List<DuplicationCode>(),
-                DependencyList = new List<DependencyRelation>(),
-                ProcessingTime = TimeSpan.FromSeconds(10),
-                SolutionFileName = "CodeLineCounter.sln",
-                DuplicatedLines = 100
-            };
-            var verbose = true;
-
             using (var sw = new StringWriter())
             {
                 Console.SetOut(sw);
+                // Arrange
+                var result = new AnalysisResult
+                {
+                    Metrics = new List<NamespaceMetrics>(),
+                    ProjectTotals = new Dictionary<string, int>(),
+                    TotalLines = 1000,
+                    TotalFiles = 10,
+                    DuplicationMap = new List<DuplicationCode>(),
+                    DependencyList = new List<DependencyRelation>(),
+                    ProcessingTime = TimeSpan.FromSeconds(10),
+                    SolutionFileName = "CodeLineCounter.sln",
+                    DuplicatedLines = 100
+                };
+                var verbose = true;
 
                 // Act
                 SolutionAnalyzer.OutputAnalysisResults(result, verbose);
@@ -124,40 +156,39 @@ namespace CodeLineCounter.Tests.Services
         [Fact]
         public void OutputDetailedMetrics_ShouldPrintMetricsAndProjectTotals()
         {
-            // Arrange
-            var metrics = new List<NamespaceMetrics>
-            {
-                new NamespaceMetrics
-                {
-                    ProjectName = "Project1",
-                    ProjectPath = "/path/to/project1",
-                    NamespaceName = "Namespace1",
-                    FileName = "File1.cs",
-                    FilePath = "/path/to/project1/File1.cs",
-                    LineCount = 100,
-                    CyclomaticComplexity = 10
-                },
-                new NamespaceMetrics
-                {
-                    ProjectName = "Project2",
-                    ProjectPath = "/path/to/project2",
-                    NamespaceName = "Namespace2",
-                    FileName = "File2.cs",
-                    FilePath = "/path/to/project2/File2.cs",
-                    LineCount = 200,
-                    CyclomaticComplexity = 20
-                }
-            };
-
-            var projectTotals = new Dictionary<string, int>
-            {
-                { "Project1", 100 },
-                { "Project2", 200 }
-            };
-
             using (var sw = new StringWriter())
             {
                 Console.SetOut(sw);
+                // Arrange
+                var metrics = new List<NamespaceMetrics>
+                {
+                    new NamespaceMetrics
+                    {
+                        ProjectName = "Project1",
+                        ProjectPath = "/path/to/project1",
+                        NamespaceName = "Namespace1",
+                        FileName = "File1.cs",
+                        FilePath = "/path/to/project1/File1.cs",
+                        LineCount = 100,
+                        CyclomaticComplexity = 10
+                    },
+                    new NamespaceMetrics
+                    {
+                        ProjectName = "Project2",
+                        ProjectPath = "/path/to/project2",
+                        NamespaceName = "Namespace2",
+                        FileName = "File2.cs",
+                        FilePath = "/path/to/project2/File2.cs",
+                        LineCount = 200,
+                        CyclomaticComplexity = 20
+                    }
+                };
+
+                var projectTotals = new Dictionary<string, int>
+                {
+                    { "Project1", 100 },
+                    { "Project2", 200 }
+                };
 
                 // Act
                 SolutionAnalyzer.OutputDetailedMetrics(metrics, projectTotals);
@@ -177,7 +208,7 @@ namespace CodeLineCounter.Tests.Services
         [Fact]
         public void export_results_with_valid_input_exports_all_files()
         {
-          // Act
+            // Act
             using (var sw = new StringWriter())
             {
                 // Arrange
@@ -214,6 +245,7 @@ namespace CodeLineCounter.Tests.Services
                 if (disposing && Directory.Exists(_testDirectory))
                 {
                     // Dispose managed resources
+                    File.Delete(_testSolutionPath);
                     Directory.Delete(_testDirectory, true);
                 }
 

--- a/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
+++ b/CodeLineCounter.Tests/SolutionAnalyzerTests.cs
@@ -214,7 +214,7 @@ EndProject");
                 // Arrange
                 var result = new AnalysisResult
                 {
-                    SolutionFileName = "TestSolution",
+                    SolutionFileName = "CodelineCounter.sln",
                     Metrics = new List<NamespaceMetrics>(),
                     ProjectTotals = new Dictionary<string, int>(),
                     TotalLines = 1000,
@@ -222,17 +222,17 @@ EndProject");
                     DependencyList = new List<DependencyRelation>()
                 };
 
-                var basePath = _testDirectory;
-                var solutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
+                var basePath = FileUtils.GetBasePath();
+                var baseSolutionPath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", ".."));
 
-                solutionPath = Path.Combine(solutionPath, "TestSolution.sln");
+                var solutionPath = Path.Combine(baseSolutionPath, "CodelineCounter.sln");
                 var format = CoreUtils.ExportFormat.CSV;
                 Console.SetOut(sw);
-                SolutionAnalyzer.ExportResults(result, solutionPath, format);
+                SolutionAnalyzer.ExportResults(result, solutionPath, format, baseSolutionPath);
                 // Assert
-                Assert.True(File.Exists("TestSolution-CodeMetrics.csv"));
-                Assert.True(File.Exists("TestSolution-CodeDuplications.csv"));
-                Assert.True(File.Exists("TestSolution-CodeDependencies.csv"));
+                Assert.True(File.Exists(Path.Combine(baseSolutionPath, "CodelineCounter-CodeMetrics.csv")));
+                Assert.True(File.Exists(Path.Combine(baseSolutionPath, "CodelineCounter-CodeDuplications.csv")));
+                Assert.True(File.Exists(Path.Combine(baseSolutionPath, "CodelineCounter-Dependencies.dot")));
             }
 
 

--- a/CodeLineCounter/Models/Settings.cs
+++ b/CodeLineCounter/Models/Settings.cs
@@ -1,0 +1,71 @@
+using CodeLineCounter.Utils;
+
+namespace CodeLineCounter.Models
+{
+    public class Settings
+    {
+
+        public bool Verbose { get; set; }
+        public string? DirectoryPath { get; set; }
+        public string? OutputPath { get; set; }
+        public bool Help { get; set; }
+        public CoreUtils.ExportFormat Format { get; set; }
+
+        public Settings()
+        {
+            Format = CoreUtils.ExportFormat.CSV;
+            Help = false;
+            Verbose = false;
+            OutputPath = Directory.GetCurrentDirectory();
+        }
+
+        public Settings(bool verbose, string? directoryPath, string? outputPath, bool help, CoreUtils.ExportFormat format)
+        {
+            Verbose = verbose;
+            DirectoryPath = directoryPath;
+            OutputPath = outputPath;
+            Help = help;
+            Format = format;
+        }
+
+
+        public Settings(bool verbose, string? directoryPath, bool help, CoreUtils.ExportFormat format)
+        {
+            Verbose = verbose;
+            DirectoryPath = directoryPath;
+            OutputPath = OutputPath = Directory.GetCurrentDirectory();
+            Help = help;
+            Format = format;
+        }
+
+        public bool IsValid()
+        {
+            if (Help)
+            {
+                Console.WriteLine("Usage: CodeLineCounter.exe [-verbose] [-d <directory_path>] [-output <output_path>] [-help, -h] (-format <csv, json>)");
+                return true;
+            }
+
+            if (DirectoryPath == null)
+            {
+                Console.WriteLine("Please provide the directory path containing the solutions to analyze using the -d switch.");
+                return false;
+            }
+
+            if (OutputPath != null && !Directory.Exists(OutputPath))
+            {
+                try
+                {
+                    Directory.CreateDirectory(OutputPath);
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine($"Cannot create or access output directory: {OutputPath}");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+} 

--- a/CodeLineCounter/Program.cs
+++ b/CodeLineCounter/Program.cs
@@ -8,7 +8,7 @@ namespace CodeLineCounter
         static void Main(string[] args)
         {
             var settings = CoreUtils.ParseArguments(args);
-            if (!CoreUtils.CheckSettings(settings) || settings.DirectoryPath == null)
+            if (!settings.IsValid() || settings.DirectoryPath == null)
                 return;
 
             // file deepcode ignore PT: Not a web server. This software is a console application.
@@ -23,7 +23,7 @@ namespace CodeLineCounter
             // if more than one waiting for user selection
             if (solutionFiles.Count == 1)
             {
-                SolutionAnalyzer.AnalyzeAndExportSolution(solutionFiles[0], settings.Verbose, settings.format);
+                SolutionAnalyzer.AnalyzeAndExportSolution(solutionFiles[0], settings.Verbose, settings.Format, settings.OutputPath);
                 return;
             }
 
@@ -35,7 +35,7 @@ namespace CodeLineCounter
                 return;
 
             var solutionPath = Path.GetFullPath(solutionFiles[choice - 1]);
-            SolutionAnalyzer.AnalyzeAndExportSolution(solutionPath, settings.Verbose, settings.format);
+            SolutionAnalyzer.AnalyzeAndExportSolution(solutionPath, settings.Verbose, settings.Format, settings.OutputPath);
         }
     }
 }

--- a/CodeLineCounter/Services/DependencyGraphGenerator.cs
+++ b/CodeLineCounter/Services/DependencyGraphGenerator.cs
@@ -163,7 +163,7 @@ namespace CodeLineCounter.Services
             }
         }
 
-        public static async Task CompileGraphAndWriteToFile(string outputPath, DotGraph graph)
+        public static async Task CompileGraphAndWriteToFile(string fileName,string outputPath, DotGraph graph)
         {
             // Use memory buffer
             using var memoryStream = new MemoryStream();
@@ -178,7 +178,7 @@ namespace CodeLineCounter.Services
             await writer.FlushAsync(); // Ensure all data is written to memory
 
             memoryStream.Position = 0; // Reset position to start
-            using var fileStream = File.Create(outputPath);
+            using var fileStream = File.Create(Path.Combine(outputPath, fileName));
             await memoryStream.CopyToAsync(fileStream); // Write complete buffer to file
         }
 
@@ -223,6 +223,5 @@ namespace CodeLineCounter.Services
         {
             return str.Replace("\"", "");
         }
-
     }
 }

--- a/CodeLineCounter/Services/SolutionAnalyzer.cs
+++ b/CodeLineCounter/Services/SolutionAnalyzer.cs
@@ -71,11 +71,22 @@ namespace CodeLineCounter.Services
             
             // Export metrics
             string metricsFileName = $"{baseFileName}-CodeMetrics";
-            string metricsOutputPath = CoreUtils.GetExportFileNameWithExtension(metricsFileName, format, outputPath);
+            metricsFileName = CoreUtils.GetExportFileNameWithExtension(metricsFileName, format);
+            if (string.IsNullOrEmpty(outputPath))
+            {
+                outputPath = ".";
+            }   
+
+            string metricsOutputPath = outputPath != null 
+                ? Path.Combine(outputPath, metricsFileName)
+                : metricsFileName;
 
             // Export duplications
             string duplicationsFileName = $"{baseFileName}-CodeDuplication";
-            string duplicationsOutputPath = CoreUtils.GetExportFileNameWithExtension(duplicationsFileName, format, outputPath);
+            duplicationsFileName = CoreUtils.GetExportFileNameWithExtension(duplicationsFileName, format);
+            string duplicationsOutputPath = outputPath != null 
+                ? Path.Combine(outputPath, duplicationsFileName)
+                : duplicationsFileName;
             // Export des duplications...
 
             // Export dependencies graph
@@ -88,19 +99,19 @@ namespace CodeLineCounter.Services
             {
                 Parallel.Invoke(
                     () => DataExporter.ExportMetrics(
-                        metricsOutputPath,
-                        result.Metrics,
-                        result.ProjectTotals,
-                        result.TotalLines,
-                        result.DuplicationMap,
+                        metricsFileName,
+                        outputPath ??".",
+                        result,
                         solutionPath,
                         format),
                     () => DataExporter.ExportDuplications(
-                        duplicationsOutputPath,
+                        duplicationsFileName,
+                        outputPath ?? ".",
                         result.DuplicationMap,
                         format),
                     async () => await DataExporter.ExportDependencies(
-                        graphOutputPath,
+                        graphFileName,
+                        outputPath ?? ".",
                         result.DependencyList,
                         format)
                 );

--- a/CodeLineCounter/Services/SolutionAnalyzer.cs
+++ b/CodeLineCounter/Services/SolutionAnalyzer.cs
@@ -82,7 +82,7 @@ namespace CodeLineCounter.Services
                 : metricsFileName;
 
             // Export duplications
-            string duplicationsFileName = $"{baseFileName}-CodeDuplication";
+            string duplicationsFileName = $"{baseFileName}-CodeDuplications";
             duplicationsFileName = CoreUtils.GetExportFileNameWithExtension(duplicationsFileName, format);
             string duplicationsOutputPath = outputPath != null 
                 ? Path.Combine(outputPath, duplicationsFileName)

--- a/CodeLineCounter/Services/SolutionAnalyzer.cs
+++ b/CodeLineCounter/Services/SolutionAnalyzer.cs
@@ -69,22 +69,20 @@ namespace CodeLineCounter.Services
         {
             string baseFileName = Path.GetFileNameWithoutExtension(solutionPath);
             
-            // Export des métriques
+            // Export metrics
             string metricsFileName = $"{baseFileName}-CodeMetrics";
             string metricsOutputPath = CoreUtils.GetExportFileNameWithExtension(metricsFileName, format, outputPath);
-            // Export des métriques...
 
-            // Export des duplications
+            // Export duplications
             string duplicationsFileName = $"{baseFileName}-CodeDuplication";
             string duplicationsOutputPath = CoreUtils.GetExportFileNameWithExtension(duplicationsFileName, format, outputPath);
             // Export des duplications...
 
-            // Export du graphe de dépendances
+            // Export dependencies graph
             string graphFileName = $"{baseFileName}-Dependencies.dot";
             string graphOutputPath = outputPath != null 
                 ? Path.Combine(outputPath, graphFileName)
                 : graphFileName;
-            // Export du graphe...
 
             try
             {

--- a/CodeLineCounter/Utils/CoreUtils.cs
+++ b/CodeLineCounter/Utils/CoreUtils.cs
@@ -138,7 +138,7 @@ namespace CodeLineCounter.Utils
             }
         }
 
-        public static string GetExportFileNameWithExtension(string filePath, CoreUtils.ExportFormat format, string? outputPath = null)
+        public static string GetExportFileNameWithExtension(string filePath, ExportFormat format, string? outputPath = null)
         {
             string fileName = Path.GetFileName(filePath);
             if (filePath == null)
@@ -147,15 +147,28 @@ namespace CodeLineCounter.Utils
             }
             string newExtension = format switch
             {
-                CoreUtils.ExportFormat.CSV => ".csv",
-                CoreUtils.ExportFormat.JSON => ".json",
+                ExportFormat.CSV => ".csv",
+                ExportFormat.JSON => ".json",
                 _ => throw new ArgumentException($"Unsupported format: {format}", nameof(format))
             };
 
+            string currentExtension = Path.GetExtension(filePath);
+
             // If file already has the desired extension, keep it, otherwise change it
-            if (!Path.GetExtension(fileName).Equals(newExtension, StringComparison.OrdinalIgnoreCase))
+            if (!currentExtension.Equals(newExtension, StringComparison.OrdinalIgnoreCase))
             {
-                fileName = Path.ChangeExtension(fileName, newExtension);
+                if (!string.IsNullOrEmpty(currentExtension))
+                {
+                    fileName = Path.ChangeExtension(fileName, newExtension);
+                }
+                else
+                {
+                    fileName = fileName + newExtension;
+                }
+            }
+            else 
+            {
+                fileName = filePath;
             }
 
             // If an output directory is specified, combine the path

--- a/CodeLineCounter/Utils/CoreUtils.cs
+++ b/CodeLineCounter/Utils/CoreUtils.cs
@@ -14,62 +14,68 @@ namespace CodeLineCounter.Utils
         {
             var settings = new Settings();
             int argIndex = 0;
-            
+
             while (argIndex < args.Length)
             {
                 switch (args[argIndex])
                 {
                     case "-help":
                         settings.Help = true;
-                        argIndex++;
                         break;
                     case "-verbose":
                         settings.Verbose = true;
-                        argIndex++;
                         break;
                     case "-d":
-                        if (argIndex + 1 < args.Length)
-                        {
-                            settings.DirectoryPath = args[argIndex + 1];
-                            argIndex += 2;
-                        }
-                        else
-                        {
-                            argIndex++;
-                        }
+                        HandleDirectory(args, settings, ref argIndex);
                         break;
                     case "-format":
-                        if (argIndex + 1 < args.Length)
-                        {
-                            string formatString = args[argIndex + 1];
-                            argIndex += 2;
-                            if (Enum.TryParse<ExportFormat>(formatString, true, out ExportFormat result))
-                            {
-                                settings.Format = result;
-                            }
-                            else
-                            {
-                                Console.WriteLine($"Invalid format: {formatString}. Valid formats are: {string.Join(", ", Enum.GetNames<ExportFormat>())}. Using default format {settings.Format}");
-                            }
-                        }
+                        HandleFormat(args, settings, ref argIndex);
                         break;
                     case "-output":
-                        if (argIndex + 1 < args.Length)
-                        {
-                            settings.OutputPath = args[argIndex + 1];
-                            argIndex += 2;
-                        }
-                        else
-                        {
-                            argIndex++;
-                        }
+                        HandleOutput(args, settings, ref argIndex);
                         break;
                     default:
-                        argIndex++;
                         break;
                 }
+                argIndex++;
             }
             return settings;
+        }
+
+        private static void HandleDirectory(string[] args, Settings settings, ref int argIndex)
+        {
+            if (argIndex + 1 < args.Length)
+            {
+                settings.DirectoryPath = args[argIndex + 1];
+                argIndex++;
+            }
+
+        }
+
+        private static void HandleFormat(string[] args, Settings settings, ref int argIndex)
+        {
+            if (argIndex + 1 < args.Length)
+            {
+                string formatString = args[argIndex + 1];
+                argIndex++;
+                if (Enum.TryParse<ExportFormat>(formatString, true, out ExportFormat result))
+                {
+                    settings.Format = result;
+                }
+                else
+                {
+                    Console.WriteLine($"Invalid format: {formatString}. Valid formats are: {string.Join(", ", Enum.GetNames<ExportFormat>())}. Using default format {settings.Format}");
+                }
+            }
+        }
+
+        private static void HandleOutput(string[] args, Settings settings, ref int argIndex)
+        {
+            if (argIndex + 1 < args.Length)
+            {
+                settings.OutputPath = args[argIndex + 1];
+                argIndex++;
+            }
         }
 
         /// <summary>
@@ -153,9 +159,9 @@ namespace CodeLineCounter.Utils
             }
 
             // If an output directory is specified, combine the path
-            return outputPath != null 
+            return outputPath != null
                 ? Path.Combine(Path.GetFullPath(outputPath), fileName)
                 : Path.Combine(Path.GetDirectoryName(filePath) ?? Path.GetFullPath("."), fileName);
-        } 
+        }
     }
 }

--- a/CodeLineCounter/Utils/CoreUtils.cs
+++ b/CodeLineCounter/Utils/CoreUtils.cs
@@ -138,13 +138,14 @@ namespace CodeLineCounter.Utils
             }
         }
 
-        public static string GetExportFileNameWithExtension(string filePath, ExportFormat format, string? outputPath = null)
+        public static string GetExportFileNameWithExtension(string filePath, ExportFormat format)
         {
-            string fileName = Path.GetFileName(filePath);
             if (filePath == null)
             {
-                filePath = ".";
+                filePath = "export.";
             }
+            string fileName = Path.GetFileName(filePath);
+            
             string newExtension = format switch
             {
                 ExportFormat.CSV => ".csv",
@@ -172,9 +173,7 @@ namespace CodeLineCounter.Utils
             }
 
             // If an output directory is specified, combine the path
-            return outputPath != null
-                ? Path.Combine(Path.GetFullPath(outputPath), fileName)
-                : Path.Combine(Path.GetDirectoryName(filePath) ?? Path.GetFullPath("."), fileName);
+            return fileName;
         }
     }
 }

--- a/CodeLineCounter/Utils/CoreUtils.cs
+++ b/CodeLineCounter/Utils/CoreUtils.cs
@@ -1,3 +1,4 @@
+using CodeLineCounter.Models;
 
 namespace CodeLineCounter.Utils
 {
@@ -8,49 +9,59 @@ namespace CodeLineCounter.Utils
             CSV,
             JSON
         }
-        public static (bool Verbose, string? DirectoryPath, bool Help, ExportFormat format) ParseArguments(string[] args)
+
+        public static Settings ParseArguments(string[] args)
         {
-            bool verbose = false;
-            bool help = false;
-            ExportFormat format = ExportFormat.CSV;
-            string? directoryPath = null;
+            var settings = new Settings();
             int argIndex = 0;
+            
             while (argIndex < args.Length)
             {
                 switch (args[argIndex])
                 {
                     case "-help":
-                        help = true;
+                        settings.Help = true;
                         argIndex++;
                         break;
                     case "-verbose":
-                        verbose = true;
+                        settings.Verbose = true;
                         argIndex++;
                         break;
                     case "-d":
                         if (argIndex + 1 < args.Length)
                         {
-                            directoryPath = args[argIndex + 1];
-                            argIndex += 2; // Increment by 2 to skip the next argument
+                            settings.DirectoryPath = args[argIndex + 1];
+                            argIndex += 2;
                         }
                         else
                         {
-                            argIndex++; // Increment by 1 if there's no next argument
+                            argIndex++;
                         }
                         break;
                     case "-format":
                         if (argIndex + 1 < args.Length)
                         {
                             string formatString = args[argIndex + 1];
-                            argIndex += 2; // Increment by 2 to skip the next argument
+                            argIndex += 2;
                             if (Enum.TryParse<ExportFormat>(formatString, true, out ExportFormat result))
                             {
-                                format = result;
+                                settings.Format = result;
                             }
                             else
                             {
-                                Console.WriteLine($"Invalid format: {formatString}. Valid formats are: {string.Join(", ", Enum.GetNames<ExportFormat>())}. Using default format {format}");
+                                Console.WriteLine($"Invalid format: {formatString}. Valid formats are: {string.Join(", ", Enum.GetNames<ExportFormat>())}. Using default format {settings.Format}");
                             }
+                        }
+                        break;
+                    case "-output":
+                        if (argIndex + 1 < args.Length)
+                        {
+                            settings.OutputPath = args[argIndex + 1];
+                            argIndex += 2;
+                        }
+                        else
+                        {
+                            argIndex++;
                         }
                         break;
                     default:
@@ -58,7 +69,7 @@ namespace CodeLineCounter.Utils
                         break;
                 }
             }
-            return (verbose, directoryPath, help, format);
+            return settings;
         }
 
         /// <summary>
@@ -121,25 +132,13 @@ namespace CodeLineCounter.Utils
             }
         }
 
-        public static bool CheckSettings((bool Verbose, string? DirectoryPath, bool Help, ExportFormat format) settings)
+        public static string GetExportFileNameWithExtension(string filePath, CoreUtils.ExportFormat format, string? outputPath = null)
         {
-            if (settings.Help)
+            string fileName = Path.GetFileName(filePath);
+            if (filePath == null)
             {
-                Console.WriteLine("Usage: CodeLineCounter.exe [-verbose] [-d <directory_path>] [-help, -h] (-format <csv, json>)");
-                return false;
+                filePath = ".";
             }
-
-            if (settings.DirectoryPath == null)
-            {
-                Console.WriteLine("Please provide the directory path containing the solutions to analyze using the -d switch.");
-                return false;
-            }
-
-            return true;
-        }
-
-        public static string GetExportFileNameWithExtension(string filePath, CoreUtils.ExportFormat format)
-        {
             string newExtension = format switch
             {
                 CoreUtils.ExportFormat.CSV => ".csv",
@@ -147,23 +146,16 @@ namespace CodeLineCounter.Utils
                 _ => throw new ArgumentException($"Unsupported format: {format}", nameof(format))
             };
 
-            string currentExtension = Path.GetExtension(filePath);
-
-            // If the file already has the desired extension (case-insensitive)
-            if (currentExtension.Equals(newExtension, StringComparison.OrdinalIgnoreCase))
+            // If file already has the desired extension, keep it, otherwise change it
+            if (!Path.GetExtension(fileName).Equals(newExtension, StringComparison.OrdinalIgnoreCase))
             {
-                return filePath;
+                fileName = Path.ChangeExtension(fileName, newExtension);
             }
 
-            // If the file has no extension, add the new one
-            if (string.IsNullOrEmpty(currentExtension))
-            {
-                return filePath + newExtension;
-            }
-
-            // If the file has a different extension, replace it
-            return Path.ChangeExtension(filePath, newExtension);
-        }
+            // If an output directory is specified, combine the path
+            return outputPath != null 
+                ? Path.Combine(Path.GetFullPath(outputPath), fileName)
+                : Path.Combine(Path.GetDirectoryName(filePath) ?? Path.GetFullPath("."), fileName);
+        } 
     }
-
 }

--- a/CodeLineCounter/Utils/DataExporter.cs
+++ b/CodeLineCounter/Utils/DataExporter.cs
@@ -14,32 +14,33 @@ namespace CodeLineCounter.Utils
             { CoreUtils.ExportFormat.JSON, new JsonExportStrategy() }
         };
 
-        public static void Export<T>(string filePath, T data, CoreUtils.ExportFormat format) where T : class
+        public static void Export<T>(string baseFilename, string outputPath, T data, CoreUtils.ExportFormat format) where T : class
         {
             ArgumentNullException.ThrowIfNull(data);
 
-            ExportCollection(filePath, [data], format);
+            ExportCollection(baseFilename, outputPath, [data], format);
         }
 
-        public static void ExportCollection<T>(string? filePath, IEnumerable<T> data, CoreUtils.ExportFormat format) where T : class
+
+        public static void ExportCollection<T>(string? filename, string outputPath, IEnumerable<T> data, CoreUtils.ExportFormat format) where T : class
         {
-            if (string.IsNullOrEmpty(filePath))
-                throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
+            if (string.IsNullOrEmpty(filename))
+                throw new ArgumentException("File path cannot be null or empty", nameof(filename));
             
             ArgumentNullException.ThrowIfNull(data);
 
             try
             {
-                filePath = CoreUtils.GetExportFileNameWithExtension(filePath, format);
-                _exportStrategies[format].Export(filePath, data);
+                filename = CoreUtils.GetExportFileNameWithExtension(filename, format);
+                _exportStrategies[format].Export(filename, outputPath, data);
             }
             catch (IOException ex)
             {
-                throw new IOException($"Failed to export data to {filePath}", ex);
+                throw new IOException($"Failed to export data to {filename}", ex);
             }
         }
 
-        public static void ExportDuplications(string outputPath, List<DuplicationCode> duplications, CoreUtils.ExportFormat format)
+        public static void ExportDuplications(string baseFileName, string outputPath, List<DuplicationCode> duplications, CoreUtils.ExportFormat format)
         {
             string? directory = Path.GetDirectoryName(outputPath);
             if (!string.IsNullOrEmpty(directory))
@@ -47,43 +48,46 @@ namespace CodeLineCounter.Utils
                 Directory.CreateDirectory(directory);
             }
 
-            ExportCollection(outputPath, duplications, format);
+            ExportCollection(baseFileName,outputPath, duplications, format);
         }
 
-        public static async Task ExportDependencies(string outputPath, List<DependencyRelation> dependencies, CoreUtils.ExportFormat format)
+        public static async Task ExportDependencies(string baseFileName,string outputPath, List<DependencyRelation> dependencies, CoreUtils.ExportFormat format)
         {
             string? directory = Path.GetDirectoryName(outputPath);
             if (!string.IsNullOrEmpty(directory))
             {
                 Directory.CreateDirectory(directory);
             }
-            string outputFilePath = CoreUtils.GetExportFileNameWithExtension(outputPath, format);
-            ExportCollection(outputFilePath, dependencies, format);
+            string filename = CoreUtils.GetExportFileNameWithExtension(baseFileName, format);
+            
+
+            ExportCollection(filename,outputPath, dependencies, format);
 
             DotGraph graph = DependencyGraphGenerator.GenerateGraphOnly(dependencies);
 
-            await DependencyGraphGenerator.CompileGraphAndWriteToFile(outputPath, graph);
+            filename = Path.ChangeExtension(filename, ".dot");
+
+            await DependencyGraphGenerator.CompileGraphAndWriteToFile(filename, outputPath, graph);
         }
 
-        public static void ExportMetrics(string outputPath, List<NamespaceMetrics> metrics, 
-            Dictionary<string, int> projectTotals, int totalLines, 
-            List<DuplicationCode> duplicationMap, string solutionPath, CoreUtils.ExportFormat format)
+        public static void ExportMetrics(string baseFilename, string outputPath, AnalysisResult analyzeMetrics, string solutionPath,CoreUtils.ExportFormat format)
         {
             string? directory = Path.GetDirectoryName(outputPath);
             if (!string.IsNullOrEmpty(directory))
             {
                 Directory.CreateDirectory(directory);
             }
-            var filePath = CoreUtils.GetExportFileNameWithExtension(outputPath, format);
+            string TOTAL = "Total";
+            var filePath = CoreUtils.GetExportFileNameWithExtension(baseFilename, format);
 
             try
             {
                 string? currentProject = null;
                 
                 List<NamespaceMetrics> namespaceMetrics = [];
-                var duplicationCounts = GetDuplicationCounts(duplicationMap);
+                var duplicationCounts = GetDuplicationCounts(analyzeMetrics.DuplicationMap);
 
-                foreach (var metric in metrics)
+                foreach (var metric in analyzeMetrics.Metrics)
                 {
                     if (!string.Equals(currentProject, metric.ProjectName, System.StringComparison.OrdinalIgnoreCase))
                     {
@@ -92,8 +96,8 @@ namespace CodeLineCounter.Utils
                             namespaceMetrics.Add(new NamespaceMetrics
                             {
                                 ProjectName = currentProject,
-                                ProjectPath = "Total",
-                                LineCount = projectTotals[currentProject]
+                                ProjectPath = TOTAL,
+                                LineCount = analyzeMetrics.ProjectTotals[currentProject]
                             });
                         }
                         currentProject = metric.ProjectName;
@@ -107,22 +111,22 @@ namespace CodeLineCounter.Utils
                     namespaceMetrics.Add(new NamespaceMetrics
                     {
                         ProjectName = currentProject,
-                        ProjectPath = "Total",
-                        LineCount = projectTotals[currentProject]
+                        ProjectPath = TOTAL,
+                        LineCount = analyzeMetrics.ProjectTotals[currentProject]
                     });
                     namespaceMetrics.Add(new NamespaceMetrics
                     {
-                        ProjectName = "Total",
+                        ProjectName = TOTAL,
                         ProjectPath = "",
-                        LineCount = totalLines
+                        LineCount = analyzeMetrics.TotalLines
                     });
                 }
 
-                ExportCollection(outputPath, namespaceMetrics, format);
+                ExportCollection(filePath, outputPath, namespaceMetrics, format);
             }
             catch (IOException ex)
             {
-                throw new IOException($"Failed to export metrics to {filePath}", ex);
+                throw new IOException($"Failed to export metrics to {outputPath}/{filePath}", ex);
             }
 
         }
@@ -153,22 +157,22 @@ namespace CodeLineCounter.Utils
 
     public interface IExportStrategy
     {
-        void Export<T>(string filePath, IEnumerable<T> data) where T : class;
+        void Export<T>(string filePath, string outputPath, IEnumerable<T> data) where T : class;
     }
 
     public class CsvExportStrategy : IExportStrategy
     {
-        public void Export<T>(string filePath, IEnumerable<T> data) where T : class
+        public void Export<T>(string filePath, string outputPath, IEnumerable<T> data) where T : class
         {
-            CsvHandler.Serialize(data, filePath);
+            CsvHandler.Serialize(data, Path.Combine(outputPath, filePath));
         }
     }
 
     public class JsonExportStrategy : IExportStrategy
     {
-        public void Export<T>(string filePath, IEnumerable<T> data) where T : class
+        public void Export<T>(string filePath,string outputPath, IEnumerable<T> data) where T : class
         {
-            JsonHandler.Serialize(data, filePath);
+            JsonHandler.Serialize(data, Path.Combine(outputPath, filePath));
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ dotnet run --project CodeLineCounter/CodeLineCounter.csproj -verbose -d "path/to
 
 - Select the solution to analyze by entering the corresponding number.
 
+### exemple 
+
+```sh
+CodeLineCounter.exe [-verbose] [-d <directory_path>] [-output <output_path>] [-format <format>] [-help]
+```
+
+### Arguments disponibles
+
+```sh
+- `-d <directory_path>` : Chemin du répertoire contenant les solutions à analyser (obligatoire)
+- `-output <output_path>` : Répertoire de destination pour les fichiers de résultats (optionnel, par défaut: répertoire courant)
+- `-format <format>` : Format d'export des résultats (optionnel)
+  - Valeurs possibles : `csv`, `json`
+  - Par défaut : `csv`
+- `-verbose` : Active les logs détaillés (optionnel)
+- `-help` : Affiche l'aide
+```
+
 ## Generated Files
 
 The program generates a CSV file named `<SolutionName>-CodeMetrics.csv` containing the following metrics:
@@ -177,6 +195,7 @@ CodeLineCounter/
 │   │   └── Dependencies.cs
 │   │   └── DuplicationCode.cs
 │   │   └── NamespaceMetrics.cs
+│   │   └── Settings.cs
 │   ├── Services/
 │   │   ├── CodeMetricsAnalyzer.cs
 │   │   ├── CodeDuplicationChecker.cs

--- a/README.md
+++ b/README.md
@@ -80,22 +80,22 @@ dotnet run --project CodeLineCounter/CodeLineCounter.csproj -verbose -d "path/to
 
 - Select the solution to analyze by entering the corresponding number.
 
-### exemple 
+### Example
 
 ```sh
 CodeLineCounter.exe [-verbose] [-d <directory_path>] [-output <output_path>] [-format <format>] [-help]
 ```
 
-### Arguments disponibles
+### Available Arguments
 
 ```sh
-- `-d <directory_path>` : Chemin du répertoire contenant les solutions à analyser (obligatoire)
-- `-output <output_path>` : Répertoire de destination pour les fichiers de résultats (optionnel, par défaut: répertoire courant)
-- `-format <format>` : Format d'export des résultats (optionnel)
-  - Valeurs possibles : `csv`, `json`
-  - Par défaut : `csv`
-- `-verbose` : Active les logs détaillés (optionnel)
-- `-help` : Affiche l'aide
+- `-d <directory_path>` : Directory path containing the solutions to analyze (required)
+- `-output <output_path>` : Destination directory for result files (optional, default: current directory)
+- `-format <format>` : Export format for results (optional)
+  - Possible values: `csv`, `json`
+  - Default: `csv`
+- `-verbose` : Enable detailed logging (optional)
+- `-help` : Display help
 ```
 
 ## Generated Files


### PR DESCRIPTION
This pull request includes several changes to improve the test coverage and functionality of the `CodeLineCounter` project. The main changes involve adding new test cases, refactoring existing tests, and updating the project configuration.

### Test Coverage Improvements:
* [`CodeLineCounter.Tests/CodeAnalyzerTests.cs`](diffhunk://#diff-e785a61c48f6bb65d109c118e04133676dda558a34441065e6f338c278aa3e1fR12-R14): Added `StringWriter` to capture console output in multiple test methods to ensure output does not interfere with test results. [[1]](diffhunk://#diff-e785a61c48f6bb65d109c118e04133676dda558a34441065e6f338c278aa3e1fR12-R14) [[2]](diffhunk://#diff-e785a61c48f6bb65d109c118e04133676dda558a34441065e6f338c278aa3e1fR34-R37) [[3]](diffhunk://#diff-e785a61c48f6bb65d109c118e04133676dda558a34441065e6f338c278aa3e1fR53-R64) [[4]](diffhunk://#diff-e785a61c48f6bb65d109c118e04133676dda558a34441065e6f338c278aa3e1fR82-R90) [[5]](diffhunk://#diff-e785a61c48f6bb65d109c118e04133676dda558a34441065e6f338c278aa3e1fR108-R109)
* [`CodeLineCounter.Tests/CodeDuplicationCheckerTests.cs`](diffhunk://#diff-4d9ade4ff578a88e25a9b989cdd0d5227982358a08c0aa654be4c62606a57cb4L5-R24): Introduced `IDisposable` to manage temporary test directories and ensure proper cleanup after tests. [[1]](diffhunk://#diff-4d9ade4ff578a88e25a9b989cdd0d5227982358a08c0aa654be4c62606a57cb4L5-R24) [[2]](diffhunk://#diff-4d9ade4ff578a88e25a9b989cdd0d5227982358a08c0aa654be4c62606a57cb4R73-R76) [[3]](diffhunk://#diff-4d9ade4ff578a88e25a9b989cdd0d5227982358a08c0aa654be4c62606a57cb4L88-R105) [[4]](diffhunk://#diff-4d9ade4ff578a88e25a9b989cdd0d5227982358a08c0aa654be4c62606a57cb4R118-R126) [[5]](diffhunk://#diff-4d9ade4ff578a88e25a9b989cdd0d5227982358a08c0aa654be4c62606a57cb4L129-R152) [[6]](diffhunk://#diff-4d9ade4ff578a88e25a9b989cdd0d5227982358a08c0aa654be4c62606a57cb4R162-R190)
* [`CodeLineCounter.Tests/CoreUtilsTests.cs`](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR2-R77): Added `StringWriter` to capture console output and refactored tests to use `IDisposable` for managing temporary directories and resources. [[1]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR2-R77) [[2]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR86-R87) [[3]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fL76-R96) [[4]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR105-R106) [[5]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fL102-L110) [[6]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fL119-R146) [[7]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR157-R188) [[8]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR199-R212) [[9]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR223-R237) [[10]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR247-R250) [[11]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fL200-R267) [[12]](diffhunk://#diff-f222e75bbb83bb3d925f8a3b06b8c5ea539317cda046dce0e40e74b6c246e60fR282-R289)

### Project Configuration:
* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R23-R32): Added a new launch configuration for `CodeLineCounter` with output path arguments to facilitate easier debugging and testing.